### PR TITLE
Fix bridge.permissions not configured after clean login

### DIFF
--- a/cmd/bbctl/auth.go
+++ b/cmd/bbctl/auth.go
@@ -181,10 +181,15 @@ func cmdLogin(ctx *cli.Context) error {
 
 	envCfg := cfg.Environments.Get("prod")
 	envCfg.AccessToken = matrixResp.AccessToken
-	if apiResp.Whoami != nil {
-		envCfg.Username = apiResp.Whoami.UserInfo.Username
-		envCfg.ClusterID = apiResp.Whoami.UserInfo.BridgeClusterID
+	whoami := apiResp.Whoami
+	if whoami == nil {
+		whoami, err = beeperapi.Whoami(baseDomain, matrixResp.AccessToken)
+		if err != nil {
+			return fmt.Errorf("failed to get user details: %w", err)
+		}
 	}
+	envCfg.Username = whoami.UserInfo.Username
+	envCfg.ClusterID = whoami.UserInfo.BridgeClusterID
 	if err = cfg.Save(); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}


### PR DESCRIPTION
When beeperapi.SendLoginCode returns Whoami: nil, the username and cluster ID were never saved to the bbctl config. This caused bridge config generation to produce an invalid UserID (@:beeper.com), which the bridge rejected with "bridge.permissions not configured".

Add a Whoami API fallback call when apiResp.Whoami is nil, matching the original bridge-manager behavior.