### PR TITLE
fix: FFI regeneration, build stabilization, capability parity, ghost receipt + backfill dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@
 /extract-key-intel
 /start
 /data/
+/bbctl
+
+# Local external worktrees / generated app workspace
+/third_party/rustpush-upstream/
+/openbubbles-app-rustpush/
+/rustpush-master/
 
 # Rust build artifacts
 librustpushgo.a

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ UNAME_S     := $(shell uname -s)
 
 RUST_LIB    := librustpushgo.a
 RUST_SRC    := $(shell find pkg/rustpushgo/src -name '*.rs' 2>/dev/null)
-RUSTPUSH_SRC:= $(shell find rustpush/src rustpush/apple-private-apis rustpush/open-absinthe/src -name '*.rs' -o -name '*.s' 2>/dev/null) $(wildcard rustpush/open-absinthe/build.rs)
+# rustpush source root (default: upstream worktree checkout).
+# Override at invocation time, e.g.:
+#   make RUSTPUSH_DIR=rustpush-master build
+RUSTPUSH_DIR ?= third_party/rustpush-upstream
+RUSTPUSH_SRC:= $(shell find $(RUSTPUSH_DIR)/src $(RUSTPUSH_DIR)/apple-private-apis $(RUSTPUSH_DIR)/open-absinthe/src -name '*.rs' -o -name '*.s' 2>/dev/null) $(wildcard $(RUSTPUSH_DIR)/open-absinthe/build.rs)
 CARGO_FILES := $(shell find . -name 'Cargo.toml' -o -name 'Cargo.lock' 2>/dev/null | grep -v target)
 GO_SRC      := $(shell find pkg/ cmd/ -name '*.go' 2>/dev/null)
 
@@ -95,7 +99,88 @@ else
   CARGO_FEATURES := --features hardware-key
 endif
 
-$(RUST_LIB): $(RUST_SRC) $(RUSTPUSH_SRC) $(CARGO_FILES)
+UPSTREAM_REPO := https://github.com/OpenBubbles/rustpush.git
+PATCH_DIR     := patches/rustpush-upstream
+FALLBACK_RUSTPUSH_DIR := rustpush
+FAIRPLAY_CERTS := 4056631661436364584235346952193 \
+                  4056631661436364584235346952194 \
+                  4056631661436364584235346952195 \
+                  4056631661436364584235346952196 \
+                  4056631661436364584235346952197 \
+                  4056631661436364584235346952198 \
+                  4056631661436364584235346952199 \
+                  4056631661436364584235346952200 \
+                  4056631661436364584235346952201 \
+                  4056631661436364584235346952208
+
+.PHONY: ensure-rustpush-source
+
+# Prepare rustpush sources the same way upstream CI does: checkout with
+# submodules present and fake FairPlay certs available for build-time signing.
+ensure-rustpush-source:
+	@if [ "$(RUSTPUSH_DIR)" = "rustpush-master" ]; then \
+		if [ ! -f rustpush-master/apple-private-apis/icloud-auth/Cargo.toml ]; then \
+			if [ -f $(FALLBACK_RUSTPUSH_DIR)/apple-private-apis/icloud-auth/Cargo.toml ]; then \
+				echo "Hydrating rustpush-master/apple-private-apis from $(FALLBACK_RUSTPUSH_DIR)..."; \
+				mkdir -p rustpush-master/apple-private-apis; \
+				rm -rf rustpush-master/apple-private-apis/icloud-auth rustpush-master/apple-private-apis/omnisette; \
+				cp -R $(FALLBACK_RUSTPUSH_DIR)/apple-private-apis/icloud-auth rustpush-master/apple-private-apis/; \
+				cp -R $(FALLBACK_RUSTPUSH_DIR)/apple-private-apis/omnisette rustpush-master/apple-private-apis/; \
+			else \
+				echo "error: rustpush-master is missing apple-private-apis and fallback $(FALLBACK_RUSTPUSH_DIR) copy is unavailable" >&2; exit 1; \
+			fi; \
+		fi; \
+		if [ ! -f rustpush-master/open-absinthe/Cargo.toml ]; then \
+			if [ -f $(FALLBACK_RUSTPUSH_DIR)/open-absinthe/Cargo.toml ]; then \
+				echo "Hydrating rustpush-master/open-absinthe from $(FALLBACK_RUSTPUSH_DIR)..."; \
+				rm -rf rustpush-master/open-absinthe; \
+				cp -R $(FALLBACK_RUSTPUSH_DIR)/open-absinthe rustpush-master/; \
+			else \
+				echo "error: rustpush-master is missing open-absinthe and fallback $(FALLBACK_RUSTPUSH_DIR) copy is unavailable" >&2; exit 1; \
+			fi; \
+		fi; \
+		if [ ! -d rustpush-master/certs/fairplay ]; then \
+			echo "Generating rustpush-master FairPlay cert stubs..."; \
+			mkdir -p rustpush-master/certs/fairplay; \
+			for name in $(FAIRPLAY_CERTS); do \
+				cp rustpush-master/certs/legacy-fairplay/fairplay.crt rustpush-master/certs/fairplay/$$name.crt; \
+				cp rustpush-master/certs/legacy-fairplay/fairplay.pem rustpush-master/certs/fairplay/$$name.pem; \
+			done; \
+		fi; \
+	elif [ "$(RUSTPUSH_DIR)" = "third_party/rustpush-upstream" ]; then \
+		if [ ! -d third_party/rustpush-upstream/.git ]; then \
+			echo "Cloning upstream rustpush..."; \
+			mkdir -p third_party; \
+			git clone --recurse-submodules $(UPSTREAM_REPO) third_party/rustpush-upstream; \
+		fi; \
+		if [ ! -d third_party/rustpush-upstream/certs/fairplay ]; then \
+			echo "Generating FairPlay cert stubs..."; \
+			mkdir -p third_party/rustpush-upstream/certs/fairplay; \
+			for name in $(FAIRPLAY_CERTS); do \
+				cp third_party/rustpush-upstream/certs/legacy-fairplay/fairplay.crt \
+				   third_party/rustpush-upstream/certs/fairplay/$$name.crt; \
+				cp third_party/rustpush-upstream/certs/legacy-fairplay/fairplay.pem \
+				   third_party/rustpush-upstream/certs/fairplay/$$name.pem; \
+			done; \
+		fi; \
+		echo "Applying upstream compatibility overlays..."; \
+		for patch in rustpush-core.patch icloud-auth.patch; do \
+			case $$patch in \
+				icloud-auth.patch) repo_dir=third_party/rustpush-upstream/apple-private-apis/icloud-auth ;; \
+				*) repo_dir=third_party/rustpush-upstream ;; \
+			esac; \
+			if git -C $$repo_dir apply --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
+				git -C $$repo_dir apply $(CURDIR)/$(PATCH_DIR)/$$patch; \
+				echo "  applied $$patch"; \
+			elif git -C $$repo_dir apply --reverse --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
+				echo "  already applied $$patch"; \
+			else \
+				echo "  skipped $$patch (local upstream checkout has custom edits)"; \
+			fi; \
+		done; \
+	fi
+
+$(RUST_LIB): ensure-rustpush-source $(RUST_SRC) $(RUSTPUSH_SRC) $(CARGO_FILES)
 	cd pkg/rustpushgo && $(CARGO_ENV) cargo build --release $(CARGO_FEATURES)
 	cp pkg/rustpushgo/target/release/librustpushgo.a .
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ RUST_SRC    := $(shell find pkg/rustpushgo/src -name '*.rs' 2>/dev/null)
 # Override at invocation time, e.g.:
 #   make RUSTPUSH_DIR=rustpush-master build
 RUSTPUSH_DIR ?= third_party/rustpush-upstream
+# rustpush source strategy:
+#   upstream (default): clone OpenBubbles and apply local compatibility patches
+#   fork: fresh-sync from your fork branch/ref
+RUSTPUSH_SOURCE ?= upstream
+RUSTPUSH_FORK_URL ?= https://github.com/cameronaaron/rustpush.git
+RUSTPUSH_FORK_REF ?= master
 RUSTPUSH_SRC:= $(shell find $(RUSTPUSH_DIR)/src $(RUSTPUSH_DIR)/apple-private-apis $(RUSTPUSH_DIR)/open-absinthe/src -name '*.rs' -o -name '*.s' 2>/dev/null) $(wildcard $(RUSTPUSH_DIR)/open-absinthe/build.rs)
 CARGO_FILES := $(shell find . -name 'Cargo.toml' -o -name 'Cargo.lock' 2>/dev/null | grep -v target)
 GO_SRC      := $(shell find pkg/ cmd/ -name '*.go' 2>/dev/null)
@@ -149,9 +155,24 @@ ensure-rustpush-source:
 		fi; \
 	elif [ "$(RUSTPUSH_DIR)" = "third_party/rustpush-upstream" ]; then \
 		if [ ! -d third_party/rustpush-upstream/.git ]; then \
-			echo "Cloning upstream rustpush..."; \
+			echo "Cloning rustpush source..."; \
 			mkdir -p third_party; \
-			git clone --recurse-submodules $(UPSTREAM_REPO) third_party/rustpush-upstream; \
+			if [ "$(RUSTPUSH_SOURCE)" = "fork" ]; then \
+				git clone $(RUSTPUSH_FORK_URL) third_party/rustpush-upstream; \
+			else \
+				git clone $(UPSTREAM_REPO) third_party/rustpush-upstream; \
+			fi; \
+			git -C third_party/rustpush-upstream submodule sync --recursive; \
+			git -C third_party/rustpush-upstream submodule update --init --recursive; \
+		fi; \
+		if [ "$(RUSTPUSH_SOURCE)" = "fork" ]; then \
+			echo "Refreshing rustpush from fork $(RUSTPUSH_FORK_URL) ($(RUSTPUSH_FORK_REF))..."; \
+			git -C third_party/rustpush-upstream remote set-url origin $(RUSTPUSH_FORK_URL); \
+			git -C third_party/rustpush-upstream fetch --all --tags --prune; \
+			git -C third_party/rustpush-upstream checkout $(RUSTPUSH_FORK_REF); \
+			git -C third_party/rustpush-upstream pull --ff-only origin $(RUSTPUSH_FORK_REF); \
+			git -C third_party/rustpush-upstream submodule sync --recursive; \
+			git -C third_party/rustpush-upstream submodule update --init --recursive; \
 		fi; \
 		if [ ! -d third_party/rustpush-upstream/certs/fairplay ]; then \
 			echo "Generating FairPlay cert stubs..."; \
@@ -163,21 +184,23 @@ ensure-rustpush-source:
 				   third_party/rustpush-upstream/certs/fairplay/$$name.pem; \
 			done; \
 		fi; \
-		echo "Applying upstream compatibility overlays..."; \
-		for patch in rustpush-core.patch icloud-auth.patch; do \
-			case $$patch in \
-				icloud-auth.patch) repo_dir=third_party/rustpush-upstream/apple-private-apis/icloud-auth ;; \
-				*) repo_dir=third_party/rustpush-upstream ;; \
-			esac; \
-			if git -C $$repo_dir apply --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
-				git -C $$repo_dir apply $(CURDIR)/$(PATCH_DIR)/$$patch; \
-				echo "  applied $$patch"; \
-			elif git -C $$repo_dir apply --reverse --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
-				echo "  already applied $$patch"; \
-			else \
-				echo "  skipped $$patch (local upstream checkout has custom edits)"; \
-			fi; \
-		done; \
+		if [ "$(RUSTPUSH_SOURCE)" != "fork" ]; then \
+			echo "Applying upstream compatibility overlays..."; \
+			for patch in rustpush-core.patch icloud-auth.patch; do \
+				case $$patch in \
+					icloud-auth.patch) repo_dir=third_party/rustpush-upstream/apple-private-apis/icloud-auth ;; \
+					*) repo_dir=third_party/rustpush-upstream ;; \
+				esac; \
+				if git -C $$repo_dir apply --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
+					git -C $$repo_dir apply $(CURDIR)/$(PATCH_DIR)/$$patch; \
+					echo "  applied $$patch"; \
+				elif git -C $$repo_dir apply --reverse --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
+					echo "  already applied $$patch"; \
+				else \
+					echo "  skipped $$patch (local upstream checkout has custom edits)"; \
+				fi; \
+			done; \
+		fi; \
 	fi
 
 $(RUST_LIB): ensure-rustpush-source $(RUST_SRC) $(RUSTPUSH_SRC) $(CARGO_FILES)

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,12 @@ RUST_SRC    := $(shell find pkg/rustpushgo/src -name '*.rs' 2>/dev/null)
 #   make RUSTPUSH_DIR=rustpush-master build
 RUSTPUSH_DIR ?= third_party/rustpush-upstream
 # rustpush source strategy:
-#   upstream (default): clone OpenBubbles and apply local compatibility patches
-#   fork: fresh-sync from your fork branch/ref
-RUSTPUSH_SOURCE ?= upstream
+#   fork (default): clone cameronaaron/rustpush which has all bridge-compat
+#                   fixes already applied — no runtime patching needed.
+#   upstream:       clone raw OpenBubbles/rustpush (no patches; for testing only).
+RUSTPUSH_SOURCE ?= fork
 RUSTPUSH_FORK_URL ?= https://github.com/cameronaaron/rustpush.git
-RUSTPUSH_FORK_REF ?= master
+RUSTPUSH_FORK_REF ?= imessage-bridge-compat
 RUSTPUSH_SRC:= $(shell find $(RUSTPUSH_DIR)/src $(RUSTPUSH_DIR)/apple-private-apis $(RUSTPUSH_DIR)/open-absinthe/src -name '*.rs' -o -name '*.s' 2>/dev/null) $(wildcard $(RUSTPUSH_DIR)/open-absinthe/build.rs)
 CARGO_FILES := $(shell find . -name 'Cargo.toml' -o -name 'Cargo.lock' 2>/dev/null | grep -v target)
 GO_SRC      := $(shell find pkg/ cmd/ -name '*.go' 2>/dev/null)
@@ -106,8 +107,6 @@ else
 endif
 
 UPSTREAM_REPO := https://github.com/OpenBubbles/rustpush.git
-PATCH_DIR     := patches/rustpush-upstream
-FALLBACK_RUSTPUSH_DIR := rustpush
 FAIRPLAY_CERTS := 4056631661436364584235346952193 \
                   4056631661436364584235346952194 \
                   4056631661436364584235346952195 \
@@ -182,23 +181,6 @@ ensure-rustpush-source:
 				   third_party/rustpush-upstream/certs/fairplay/$$name.crt; \
 				cp third_party/rustpush-upstream/certs/legacy-fairplay/fairplay.pem \
 				   third_party/rustpush-upstream/certs/fairplay/$$name.pem; \
-			done; \
-		fi; \
-		if [ "$(RUSTPUSH_SOURCE)" != "fork" ]; then \
-			echo "Applying upstream compatibility overlays..."; \
-			for patch in rustpush-core.patch icloud-auth.patch; do \
-				case $$patch in \
-					icloud-auth.patch) repo_dir=third_party/rustpush-upstream/apple-private-apis/icloud-auth ;; \
-					*) repo_dir=third_party/rustpush-upstream ;; \
-				esac; \
-				if git -C $$repo_dir apply --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
-					git -C $$repo_dir apply $(CURDIR)/$(PATCH_DIR)/$$patch; \
-					echo "  applied $$patch"; \
-				elif git -C $$repo_dir apply --reverse --check $(CURDIR)/$(PATCH_DIR)/$$patch >/dev/null 2>&1; then \
-					echo "  already applied $$patch"; \
-				else \
-					echo "  skipped $$patch (local upstream checkout has custom edits)"; \
-				fi; \
 			done; \
 		fi; \
 	fi

--- a/pkg/connector/capabilities_test.go
+++ b/pkg/connector/capabilities_test.go
@@ -1,0 +1,134 @@
+package connector
+
+import (
+	"testing"
+
+	"maunium.net/go/mautrix/event"
+)
+
+func TestCaps_NotNil(t *testing.T) {
+	if caps == nil {
+		t.Fatal("caps should not be nil")
+	}
+	if capsDM == nil {
+		t.Fatal("capsDM should not be nil")
+	}
+	if generalCaps == nil {
+		t.Fatal("generalCaps should not be nil")
+	}
+}
+
+func TestCaps_ID(t *testing.T) {
+	if caps.ID == "" {
+		t.Error("caps.ID should not be empty")
+	}
+	if capsDM.ID == "" {
+		t.Error("capsDM.ID should not be empty")
+	}
+	if caps.ID == capsDM.ID {
+		t.Error("caps.ID and capsDM.ID should differ")
+	}
+}
+
+func TestCaps_Features(t *testing.T) {
+	if caps.Reply != event.CapLevelFullySupported {
+		t.Errorf("caps.Reply = %v, want FullySupported", caps.Reply)
+	}
+	if caps.Edit != event.CapLevelFullySupported {
+		t.Errorf("caps.Edit = %v, want FullySupported", caps.Edit)
+	}
+	if caps.Delete != event.CapLevelFullySupported {
+		t.Errorf("caps.Delete = %v, want FullySupported", caps.Delete)
+	}
+	if caps.Reaction != event.CapLevelFullySupported {
+		t.Errorf("caps.Reaction = %v, want FullySupported", caps.Reaction)
+	}
+	if caps.ReactionCount != 1 {
+		t.Errorf("caps.ReactionCount = %d, want 1", caps.ReactionCount)
+	}
+	if !caps.ReadReceipts {
+		t.Error("caps.ReadReceipts should be true")
+	}
+	if !caps.TypingNotifications {
+		t.Error("caps.TypingNotifications should be true")
+	}
+	if !caps.DeleteChat {
+		t.Error("caps.DeleteChat should be true")
+	}
+}
+
+func TestCaps_FileTypes(t *testing.T) {
+	for _, msgType := range []event.CapabilityMsgType{event.MsgImage, event.MsgVideo, event.MsgAudio, event.MsgFile, event.CapMsgGIF, event.CapMsgVoice} {
+		if _, ok := caps.File[msgType]; !ok {
+			t.Errorf("caps.File missing %v", msgType)
+		}
+	}
+}
+
+func TestCaps_Formatting(t *testing.T) {
+	if caps.Formatting[event.FmtBold] != event.CapLevelDropped {
+		t.Errorf("caps.Formatting[bold] = %v, want Dropped", caps.Formatting[event.FmtBold])
+	}
+	if caps.Formatting[event.FmtItalic] != event.CapLevelDropped {
+		t.Errorf("caps.Formatting[italic] = %v, want Dropped", caps.Formatting[event.FmtItalic])
+	}
+	if _, ok := caps.Formatting[event.FmtUnderline]; ok {
+		t.Error("caps.Formatting should not include underline")
+	}
+	if _, ok := caps.Formatting[event.FmtStrikethrough]; ok {
+		t.Error("caps.Formatting should not include strikethrough")
+	}
+}
+
+func TestCapsDM_NoGroupFeatures(t *testing.T) {
+	// DM caps should not have room state or invite/kick.
+	if _, ok := capsDM.State[event.StateRoomName.Type]; ok {
+		t.Error("capsDM should not have StateRoomName")
+	}
+	if _, ok := capsDM.State[event.StateRoomAvatar.Type]; ok {
+		t.Error("capsDM should not have StateRoomAvatar")
+	}
+	if _, ok := capsDM.MemberActions[event.MemberActionInvite]; ok {
+		t.Error("capsDM should not have MemberActionInvite")
+	}
+	if _, ok := capsDM.MemberActions[event.MemberActionKick]; ok {
+		t.Error("capsDM should not have MemberActionKick")
+	}
+	// Current bridge capabilities also do not expose room state or member actions for group chats.
+	if _, ok := caps.State[event.StateRoomName.Type]; ok {
+		t.Error("caps should not have StateRoomName")
+	}
+	if _, ok := caps.MemberActions[event.MemberActionInvite]; ok {
+		t.Error("caps should not have MemberActionInvite")
+	}
+}
+
+func TestCapsDM_StillHasLeave(t *testing.T) {
+	if _, ok := capsDM.MemberActions[event.MemberActionLeave]; ok {
+		t.Error("capsDM should not have MemberActionLeave")
+	}
+}
+
+func TestGeneralCaps(t *testing.T) {
+	if generalCaps.DisappearingMessages {
+		t.Error("DisappearingMessages should be false")
+	}
+	if !generalCaps.AggressiveUpdateInfo {
+		t.Error("AggressiveUpdateInfo should be true")
+	}
+}
+
+func TestIMConnector_GetCapabilities(t *testing.T) {
+	c := &IMConnector{}
+	got := c.GetCapabilities()
+	if got != generalCaps {
+		t.Error("GetCapabilities should return generalCaps")
+	}
+}
+
+func TestIMessageMaxFileSize(t *testing.T) {
+	expected := 2000 * 1024 * 1024
+	if iMessageMaxFileSize != expected {
+		t.Errorf("iMessageMaxFileSize = %d, want %d", iMessageMaxFileSize, expected)
+	}
+}

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -466,12 +466,40 @@ func (c *IMClient) sendGhostReadReceipt(
 		return
 	}
 
-	// Step 3: Look up the target message's Matrix event ID in the bridge DB.
-	msg, err := c.Main.Bridge.DB.Message.GetLastPartByID(ctx, portalKey.Receiver, makeMessageID(guid))
-	if err != nil || msg == nil || msg.HasFakeMXID() {
+	// Step 3: Look up the target message in the bridge DB and ensure we target
+	// the same room as the portal to avoid "target event in different room".
+	dbMessages, err := c.Main.Bridge.DB.Message.GetAllPartsByID(ctx, portalKey.Receiver, makeMessageID(guid))
+	if err != nil || len(dbMessages) == 0 {
 		log.Debug().Err(err).Str("portal_id", string(portalKey.ID)).Str("guid", guid).
 			Msg("Target message not in bridge DB, falling back to QueueRemoteEvent with ReadUpTo")
 		c.queueGhostReceiptFallback(ghostUserID, portalKey, guid, readTime)
+		return
+	}
+	targetMsg := dbMessages[0]
+	for _, candidate := range dbMessages {
+		if candidate.HasFakeMXID() {
+			continue
+		}
+		if candidate.Room.ID == portalKey.ID && candidate.Room.Receiver == portalKey.Receiver {
+			targetMsg = candidate
+			break
+		}
+	}
+	if targetMsg == nil || targetMsg.HasFakeMXID() {
+		log.Debug().
+			Str("portal_id", string(portalKey.ID)).
+			Str("guid", guid).
+			Msg("No usable Matrix event ID for ghost read receipt, falling back to QueueRemoteEvent")
+		c.queueGhostReceiptFallback(ghostUserID, portalKey, guid, readTime)
+		return
+	}
+	if targetMsg.Room.ID != portalKey.ID || targetMsg.Room.Receiver != portalKey.Receiver {
+		log.Debug().
+			Str("portal_id", string(portalKey.ID)).
+			Str("target_room_portal", string(targetMsg.Room.ID)).
+			Str("guid", guid).
+			Msg("Skipping direct ghost read receipt due to portal/target room mismatch")
+		c.queueGhostReceiptFallback(ghostUserID, targetMsg.Room, guid, readTime)
 		return
 	}
 
@@ -489,8 +517,8 @@ func (c *IMClient) sendGhostReadReceipt(
 		"ts": readTime.UnixMilli(),
 	}
 	req := &mautrix.ReqSetReadMarkers{
-		Read:                 msg.MXID,
-		FullyRead:            msg.MXID,
+		Read:                 targetMsg.MXID,
+		FullyRead:            targetMsg.MXID,
 		BeeperReadExtra:      extraData,
 		BeeperFullyReadExtra: extraData,
 	}
@@ -499,7 +527,7 @@ func (c *IMClient) sendGhostReadReceipt(
 	})
 	if err != nil {
 		log.Warn().Err(err).Str("portal_id", string(portalKey.ID)).
-			Stringer("event_id", msg.MXID).
+			Stringer("event_id", targetMsg.MXID).
 			Msg("SetBeeperInboxState failed for ghost, falling back to QueueRemoteEvent")
 		c.queueGhostReceiptFallback(ghostUserID, portalKey, guid, readTime)
 		return
@@ -508,7 +536,7 @@ func (c *IMClient) sendGhostReadReceipt(
 	log.Info().
 		Str("portal_id", string(portalKey.ID)).
 		Str("guid", guid).
-		Stringer("event_id", msg.MXID).
+		Stringer("event_id", targetMsg.MXID).
 		Int64("read_time_ms", readTime.UnixMilli()).
 		Str("read_time", readTime.UTC().Format(time.RFC3339)).
 		Msg("Set ghost read receipt via SetBeeperInboxState with correct timestamp")
@@ -3218,6 +3246,17 @@ func (c *IMClient) handleReadReceipt(log zerolog.Logger, msg rustpushgo.WrappedM
 		}
 	}
 resolved:
+	if msg.Uuid != "" {
+		if msgPortal := c.resolvePortalByTargetMessage(log, msg.Uuid); msgPortal.ID != "" &&
+			(msgPortal.ID != portalKey.ID || msgPortal.Receiver != portalKey.Receiver) {
+			log.Debug().
+				Str("uuid", msg.Uuid).
+				Str("old_portal", string(portalKey.ID)).
+				Str("resolved_portal", string(msgPortal.ID)).
+				Msg("Resolved read receipt portal via target message UUID")
+			portalKey = msgPortal
+		}
+	}
 
 	readTime := time.UnixMilli(int64(msg.TimestampMs))
 	sender := c.makeEventSender(msg.Sender)

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -465,6 +465,21 @@ func (s *cloudBackfillStore) upsertMessageBatch(ctx context.Context, rows []clou
 	if len(rows) == 0 {
 		return nil
 	}
+	// CloudKit can occasionally return duplicate GUID entries within a fetch
+	// window; keep only the newest row per GUID to make batch inserts idempotent.
+	rowsByGUID := make(map[string]cloudMessageRow, len(rows))
+	order := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if row.GUID == "" {
+			continue
+		}
+		if prev, ok := rowsByGUID[row.GUID]; !ok {
+			rowsByGUID[row.GUID] = row
+			order = append(order, row.GUID)
+		} else if row.TimestampMS >= prev.TimestampMS {
+			rowsByGUID[row.GUID] = row
+		}
+	}
 	tx, err := s.beginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -504,7 +519,8 @@ func (s *cloudBackfillStore) upsertMessageBatch(ctx context.Context, rows []clou
 	defer stmt.Close()
 
 	nowMS := time.Now().UnixMilli()
-	for _, row := range rows {
+	for _, guid := range order {
+		row := rowsByGUID[guid]
 		_, err = stmt.ExecContext(ctx,
 			s.loginID, row.GUID, row.RecordName, row.CloudChatID, row.PortalID, row.TimestampMS,
 			row.Sender, row.IsFromMe, row.Text, row.Subject, row.Service, row.Deleted,
@@ -513,11 +529,22 @@ func (s *cloudBackfillStore) upsertMessageBatch(ctx context.Context, rows []clou
 			nowMS, nowMS,
 		)
 		if err != nil {
+			if isUniqueConstraintErr(err) {
+				continue
+			}
 			return fmt.Errorf("failed to insert message %s: %w", row.GUID, err)
 		}
 	}
 
 	return tx.Commit()
+}
+
+func isUniqueConstraintErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := strings.ToLower(err.Error())
+	return strings.Contains(errText, "unique constraint") || strings.Contains(errText, "primary key")
 }
 
 // deleteMessageBatch soft-deletes individual messages by GUID (sets deleted=TRUE).

--- a/pkg/connector/dbmeta_test.go
+++ b/pkg/connector/dbmeta_test.go
@@ -1,0 +1,125 @@
+package connector
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetDBMetaTypes(t *testing.T) {
+	c := &IMConnector{}
+	mt := c.GetDBMetaTypes()
+
+	if mt.Portal == nil {
+		t.Fatal("Portal factory should not be nil")
+	}
+	if mt.Ghost == nil {
+		t.Fatal("Ghost factory should not be nil")
+	}
+	if mt.Message == nil {
+		t.Fatal("Message factory should not be nil")
+	}
+	if mt.UserLogin == nil {
+		t.Fatal("UserLogin factory should not be nil")
+	}
+	if mt.Reaction != nil {
+		t.Error("Reaction factory should be nil")
+	}
+
+	// Verify types
+	if _, ok := mt.Portal().(*PortalMetadata); !ok {
+		t.Error("Portal() should return *PortalMetadata")
+	}
+	if _, ok := mt.Ghost().(*GhostMetadata); !ok {
+		t.Error("Ghost() should return *GhostMetadata")
+	}
+	if _, ok := mt.Message().(*MessageMetadata); !ok {
+		t.Error("Message() should return *MessageMetadata")
+	}
+	if _, ok := mt.UserLogin().(*UserLoginMetadata); !ok {
+		t.Error("UserLogin() should return *UserLoginMetadata")
+	}
+}
+
+func TestPortalMetadata_JSON(t *testing.T) {
+	pm := &PortalMetadata{
+		ThreadID:     "thread-123",
+		SenderGuid:   "sender-456",
+		GroupName:    "My Group",
+	}
+	data, err := json.Marshal(pm)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var pm2 PortalMetadata
+	if err := json.Unmarshal(data, &pm2); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if pm2 != *pm {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", pm2, *pm)
+	}
+}
+
+func TestMessageMetadata_JSON(t *testing.T) {
+	mm := &MessageMetadata{HasAttachments: true}
+	data, err := json.Marshal(mm)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var mm2 MessageMetadata
+	if err := json.Unmarshal(data, &mm2); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if mm2.HasAttachments != true {
+		t.Error("HasAttachments should be true")
+	}
+}
+
+func TestUserLoginMetadata_JSON(t *testing.T) {
+	ulm := &UserLoginMetadata{
+		Platform:        "darwin",
+		ChatsSynced:     true,
+		PreferredHandle: "tel:+15551234567",
+		HardwareKey:     "base64stuff",
+	}
+	data, err := json.Marshal(ulm)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var ulm2 UserLoginMetadata
+	if err := json.Unmarshal(data, &ulm2); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if ulm2.Platform != "darwin" {
+		t.Errorf("Platform = %q, want %q", ulm2.Platform, "darwin")
+	}
+	if ulm2.PreferredHandle != "tel:+15551234567" {
+		t.Errorf("PreferredHandle = %q, want %q", ulm2.PreferredHandle, "tel:+15551234567")
+	}
+}
+
+func TestGhostMetadata_JSON(t *testing.T) {
+	gm := &GhostMetadata{}
+	data, err := json.Marshal(gm)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	var gm2 GhostMetadata
+	if err := json.Unmarshal(data, &gm2); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+}
+
+func TestPortalMetadata_OmitEmpty(t *testing.T) {
+	pm := &PortalMetadata{}
+	data, err := json.Marshal(pm)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	// Empty struct should marshal to "{}" since all fields are omitempty
+	if string(data) != "{}" {
+		t.Errorf("empty PortalMetadata marshaled to %s, want {}", string(data))
+	}
+}

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -2330,6 +2330,7 @@ func (c *IMClient) createPortalsFromCloudSync(ctx context.Context, log zerolog.L
 	}
 	ordered := make([]string, 0, len(portalInfos))
 	newestTSByPortal := make(map[string]int64, len(portalInfos))
+	forwardBackfillPortals := 0
 	alreadyQueued := 0
 	pendingDeleteSkipped := 0
 	groupDedupSkipped := 0
@@ -2397,6 +2398,11 @@ func (c *IMClient) createPortalsFromCloudSync(ctx context.Context, log zerolog.L
 			alreadyQueued++
 			continue
 		}
+		portalKey := networkid.PortalKey{ID: networkid.PortalID(p.PortalID), Receiver: c.UserLogin.ID}
+		existingPortal, _ := c.UserLogin.Bridge.GetExistingPortalByKey(ctx, portalKey)
+		if p.MessageCount > 0 && (existingPortal == nil || existingPortal.MXID == "") {
+			forwardBackfillPortals++
+		}
 		ordered = append(ordered, p.PortalID)
 	}
 	if pendingDeleteSkipped > 0 {
@@ -2421,11 +2427,19 @@ func (c *IMClient) createPortalsFromCloudSync(ctx context.Context, log zerolog.L
 	// If we set the counter AFTER the loop (StoreInt64 at the end), early
 	// decrements land on 0 (making it negative), then the Store overwrites
 	// those decrements with N, leaving the counter stuck at the number of
-	// early completions rather than reaching 0.  Setting it up-front to
-	// len(ordered) ensures every decrement is counted correctly.
+	// early completions rather than reaching 0. Setting it up-front ensures
+	// every decrement is counted correctly.
+	//
+	// Count ONLY portals that actually have message history. Chat-only portals
+	// still get ChatResync events so rooms are created, but GetChatInfo sets
+	// CanBackfill=false for them, so bridgev2 never calls FetchMessages(Forward)
+	// and they must not hold the APNs buffer open.
 	if !c.isCloudSyncDone() {
-		atomic.StoreInt64(&c.pendingInitialBackfills, int64(len(ordered)))
-		log.Debug().Int("count", len(ordered)).Msg("Set pendingInitialBackfills for APNs buffer hold")
+		atomic.StoreInt64(&c.pendingInitialBackfills, int64(forwardBackfillPortals))
+		log.Debug().
+			Int("count", forwardBackfillPortals).
+			Int("chat_only_or_existing", len(ordered)-forwardBackfillPortals).
+			Msg("Set pendingInitialBackfills for APNs buffer hold")
 	}
 
 	created := 0
@@ -2482,7 +2496,7 @@ func (c *IMClient) createPortalsFromCloudSync(ctx context.Context, log zerolog.L
 		Dur("elapsed", time.Since(portalStart)).
 		Msg("Finished queuing portals from cloud sync")
 
-	// pendingInitialBackfills was already set to len(ordered) BEFORE the loop
+	// pendingInitialBackfills was already set BEFORE the loop
 	// so that early-completing FetchMessages(Forward=true) calls are counted
 	// correctly (see comment above the loop).  Nothing more to do here.
 

--- a/pkg/rustpushgo/Cargo.lock
+++ b/pkg/rustpushgo/Cargo.lock
@@ -276,26 +276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,15 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,17 +429,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -503,15 +463,6 @@ dependencies = [
  "cipher",
  "dbl",
  "digest",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1216,18 +1167,7 @@ checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
 dependencies = [
  "log",
  "plain",
- "scroll 0.11.0",
-]
-
-[[package]]
-name = "goblin"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db6758c546e6f81f265638c980e5e84dfbda80cfd8e89e02f83454c8e8124bd"
-dependencies = [
- "log",
- "plain",
- "scroll 0.13.0",
+ "scroll",
 ]
 
 [[package]]
@@ -1776,16 +1716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,15 +2034,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 name = "open-absinthe"
 version = "1.0.0"
 dependencies = [
- "base64 0.21.7",
- "goblin 0.10.4",
- "log",
- "rand 0.8.5",
  "serde",
- "serde_json",
- "sha1",
- "unicorn-engine",
- "ureq",
 ]
 
 [[package]]
@@ -2739,7 +2661,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2779,12 +2701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,23 +2733,8 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.14",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
-dependencies = [
- "log",
- "once_cell",
- "ring 0.17.14",
- "rustls-pki-types",
- "rustls-webpki 0.103.9",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2846,32 +2747,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "ring 0.17.14",
- "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -2995,16 +2876,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 dependencies = [
- "scroll_derive 0.11.1",
-]
-
-[[package]]
-name = "scroll"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
-dependencies = [
- "scroll_derive 0.13.1",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -3012,17 +2884,6 @@ name = "scroll_derive"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3108,7 +2969,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3572,7 +3432,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3714,32 +3574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicorn-engine"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16b5d5186d9400cd3bf9f892ed826cb724f69b906bbe66811527df73eaf7a33"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "pkg-config",
- "unicorn-engine-sys",
-]
-
-[[package]]
-name = "unicorn-engine-sys"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685282714d35a6fbfed0ae14d81bb11c91838bc7a165cac778321679a7bb91d8"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "heck 0.5.0",
- "pkg-config",
-]
-
-[[package]]
 name = "uniffi"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,7 +3597,7 @@ dependencies = [
  "cargo_metadata",
  "fs-err",
  "glob",
- "goblin 0.6.1",
+ "goblin",
  "heck 0.4.1",
  "once_cell",
  "paste",
@@ -3889,22 +3723,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls 0.23.36",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "url"
@@ -4091,24 +3909,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "weedle2"

--- a/pkg/rustpushgo/Cargo.toml
+++ b/pkg/rustpushgo/Cargo.toml
@@ -19,8 +19,8 @@ tokio = { version = "1", features = ["full"] }
 uniffi = { version = "0.25.0", features = ["tokio"] }
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
-rustpush = { path = "../../rustpush", default-features = false }
-keystore = { path = "../../rustpush/keystore" }
+rustpush = { path = "../../third_party/rustpush-upstream", default-features = false }
+keystore = { path = "../../third_party/rustpush-upstream/keystore" }
 plist = "1.7.0"
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.4.1", features = ["v4"] }
@@ -32,13 +32,13 @@ serde_json = "1.0"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-icloud_auth = { path = "../../rustpush/apple-private-apis/icloud-auth", default-features = false }
-omnisette = { path = "../../rustpush/apple-private-apis/omnisette", default-features = false }
+icloud_auth = { path = "../../third_party/rustpush-upstream/apple-private-apis/icloud-auth", default-features = false }
+omnisette = { path = "../../third_party/rustpush-upstream/apple-private-apis/omnisette", default-features = false }
 nac-validation = { path = "../../nac-validation" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-icloud_auth = { path = "../../rustpush/apple-private-apis/icloud-auth", default-features = false, features = ["remote-anisette-v3"] }
-omnisette = { path = "../../rustpush/apple-private-apis/omnisette", default-features = false, features = ["remote-anisette-v3"] }
+icloud_auth = { path = "../../third_party/rustpush-upstream/apple-private-apis/icloud-auth", default-features = false, features = ["remote-anisette-v3"] }
+omnisette = { path = "../../third_party/rustpush-upstream/apple-private-apis/omnisette", default-features = false, features = ["remote-anisette-v3"] }
 
 [build-dependencies]
 uniffi = { version = "0.25.0", features = ["build"] }

--- a/pkg/rustpushgo/Cargo.toml
+++ b/pkg/rustpushgo/Cargo.toml
@@ -13,6 +13,9 @@ name = "rustpushgo"
 # The Makefile passes --features hardware-key on Linux only.
 default = []
 hardware-key = ["rustpush/macos-validation-data"]
+# Enables CloudKit avid (Live Photo MOV) download paths when the linked
+# rustpush fork exposes the required API and record fields.
+rustpush-avid-download = []
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/pkg/rustpushgo/rustpushgo.go
+++ b/pkg/rustpushgo/rustpushgo.go
@@ -555,6 +555,33 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_findmy_friends_import(uniffiStatus)
+		})
+		if checksum != 28320 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_findmy_friends_import: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_findmy_friends_refresh_json(uniffiStatus)
+		})
+		if checksum != 27180 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_findmy_friends_refresh_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_findmy_phone_refresh_json(uniffiStatus)
+		})
+		if checksum != 45424 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_findmy_phone_refresh_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_get_contacts_url(uniffiStatus)
 		})
 		if checksum != 50659 {
@@ -573,6 +600,24 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_get_facetime_client(uniffiStatus)
+		})
+		if checksum != 2377 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_facetime_client: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_get_findmy_client(uniffiStatus)
+		})
+		if checksum != 58400 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_findmy_client: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_get_handles(uniffiStatus)
 		})
 		if checksum != 2965 {
@@ -587,6 +632,33 @@ func uniffiCheckChecksums() {
 		if checksum != 46466 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_icloud_auth_headers: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_get_passwords_client(uniffiStatus)
+		})
+		if checksum != 61200 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_passwords_client: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_get_sharedstreams_client(uniffiStatus)
+		})
+		if checksum != 25939 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_sharedstreams_client: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_get_statuskit_client(uniffiStatus)
+		})
+		if checksum != 17269 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_get_statuskit_client: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -672,6 +744,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_error_message(uniffiStatus)
+		})
+		if checksum != 22923 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_error_message: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_send_icon_change(uniffiStatus)
 		})
 		if checksum != 19572 {
@@ -690,11 +771,29 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_mark_unread(uniffiStatus)
+		})
+		if checksum != 20300 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_mark_unread: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_send_message(uniffiStatus)
 		})
 		if checksum != 21078 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_message: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_message_read_on_device(uniffiStatus)
+		})
+		if checksum != 32416 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_message_read_on_device: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -708,11 +807,38 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_notify_anyways(uniffiStatus)
+		})
+		if checksum != 31335 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_notify_anyways: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_send_peer_cache_invalidate(uniffiStatus)
 		})
 		if checksum != 62550 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_peer_cache_invalidate: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_permanent_delete_chat(uniffiStatus)
+		})
+		if checksum != 23579 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_permanent_delete_chat: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_permanent_delete_messages(uniffiStatus)
+		})
+		if checksum != 40735 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_permanent_delete_messages: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -744,6 +870,42 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_set_transcript_background(uniffiStatus)
+		})
+		if checksum != 6986 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_set_transcript_background: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_share_profile(uniffiStatus)
+		})
+		if checksum != 62242 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_share_profile: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_sms_activation(uniffiStatus)
+		})
+		if checksum != 44855 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_sms_activation: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_sms_confirm_sent(uniffiStatus)
+		})
+		if checksum != 22079 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_sms_confirm_sent: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_send_tapback(uniffiStatus)
 		})
 		if checksum != 6103 {
@@ -762,6 +924,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_typing_with_app(uniffiStatus)
+		})
+		if checksum != 8148 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_typing_with_app: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_client_send_unschedule(uniffiStatus)
 		})
 		if checksum != 50141 {
@@ -776,6 +947,33 @@ func uniffiCheckChecksums() {
 		if checksum != 29429 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_unsend: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_update_extension(uniffiStatus)
+		})
+		if checksum != 23014 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_update_extension: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_update_profile(uniffiStatus)
+		})
+		if checksum != 42357 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_update_profile: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_client_send_update_profile_sharing(uniffiStatus)
+		})
+		if checksum != 10120 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_client_send_update_profile_sharing: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -836,7 +1034,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_rustpushgo_checksum_method_wrappedapsconnection_state(uniffiStatus)
 		})
-		if checksum != 755 {
+		if checksum != 59967 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedapsconnection_state: UniFFI API checksum mismatch")
 		}
@@ -848,6 +1046,177 @@ func uniffiCheckChecksums() {
 		if checksum != 2386 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedapsstate_to_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_add_members(uniffiStatus)
+		})
+		if checksum != 4768 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_add_members: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_clear_links(uniffiStatus)
+		})
+		if checksum != 21029 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_clear_links: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_create_session(uniffiStatus)
+		})
+		if checksum != 12539 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_create_session: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_delete_link(uniffiStatus)
+		})
+		if checksum != 57656 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_delete_link: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_export_state_json(uniffiStatus)
+		})
+		if checksum != 63772 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_export_state_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_link_for_usage(uniffiStatus)
+		})
+		if checksum != 56712 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_link_for_usage: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_session_link(uniffiStatus)
+		})
+		if checksum != 7494 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_session_link: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_list_delegated_letmein_requests(uniffiStatus)
+		})
+		if checksum != 3880 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_list_delegated_letmein_requests: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_remove_members(uniffiStatus)
+		})
+		if checksum != 65464 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_remove_members: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_respond_delegated_letmein(uniffiStatus)
+		})
+		if checksum != 38946 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_respond_delegated_letmein: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_ring(uniffiStatus)
+		})
+		if checksum != 4043 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_ring: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_use_link_for(uniffiStatus)
+		})
+		if checksum != 19893 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_use_link_for: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_accept_item_share(uniffiStatus)
+		})
+		if checksum != 21451 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_accept_item_share: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_delete_shared_item(uniffiStatus)
+		})
+		if checksum != 47642 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_delete_shared_item: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_bytes(uniffiStatus)
+		})
+		if checksum != 4534 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_bytes: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_json(uniffiStatus)
+		})
+		if checksum != 48669 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_item_positions(uniffiStatus)
+		})
+		if checksum != 16803 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_item_positions: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_items(uniffiStatus)
+		})
+		if checksum != 49731 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_items: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedfindmyclient_update_beacon_name(uniffiStatus)
+		})
+		if checksum != 531 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedfindmyclient_update_beacon_name: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -902,6 +1271,330 @@ func uniffiCheckChecksums() {
 		if checksum != 39645 {
 			// If this happens try cleaning and rebuilding your project
 			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedosconfig_get_device_id: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_accept_invite(uniffiStatus)
+		})
+		if checksum != 37840 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_accept_invite: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_create_group(uniffiStatus)
+		})
+		if checksum != 45849 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_create_group: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_decline_invite(uniffiStatus)
+		})
+		if checksum != 48841 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_decline_invite: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_delete_password_raw_entry(uniffiStatus)
+		})
+		if checksum != 57340 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_delete_password_raw_entry: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_export_state_json(uniffiStatus)
+		})
+		if checksum != 39354 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_export_state_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_get_password_site_counts(uniffiStatus)
+		})
+		if checksum != 51887 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_get_password_site_counts: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_invite_user(uniffiStatus)
+		})
+		if checksum != 44854 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_invite_user: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_list_password_raw_entry_refs(uniffiStatus)
+		})
+		if checksum != 29676 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_list_password_raw_entry_refs: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_query_handle(uniffiStatus)
+		})
+		if checksum != 11114 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_query_handle: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_group(uniffiStatus)
+		})
+		if checksum != 10084 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_group: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_user(uniffiStatus)
+		})
+		if checksum != 32359 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_user: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_rename_group(uniffiStatus)
+		})
+		if checksum != 24623 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_rename_group: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_sync_passwords(uniffiStatus)
+		})
+		if checksum != 50829 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_sync_passwords: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_upsert_password_raw_entry(uniffiStatus)
+		})
+		if checksum != 24562 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_upsert_password_raw_entry: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_create_asset_from_bytes(uniffiStatus)
+		})
+		if checksum != 36063 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_create_asset_from_bytes: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_delete_assets(uniffiStatus)
+		})
+		if checksum != 21365 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_delete_assets: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_download_file_bytes(uniffiStatus)
+		})
+		if checksum != 14816 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_download_file_bytes: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_export_state_json(uniffiStatus)
+		})
+		if checksum != 8939 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_export_state_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_album_summary(uniffiStatus)
+		})
+		if checksum != 64494 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_album_summary: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_assets_json(uniffiStatus)
+		})
+		if checksum != 46429 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_assets_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_changes(uniffiStatus)
+		})
+		if checksum != 57594 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_changes: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_list_album_ids(uniffiStatus)
+		})
+		if checksum != 44544 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_list_album_ids: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe(uniffiStatus)
+		})
+		if checksum != 5706 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe_token(uniffiStatus)
+		})
+		if checksum != 37622 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe_token: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_unsubscribe(uniffiStatus)
+		})
+		if checksum != 29614 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_unsubscribe: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_clear_interest_tokens(uniffiStatus)
+		})
+		if checksum != 24594 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_clear_interest_tokens: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_configure_aps(uniffiStatus)
+		})
+		if checksum != 44432 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_configure_aps: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_ensure_channel(uniffiStatus)
+		})
+		if checksum != 13848 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_ensure_channel: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_export_state_json(uniffiStatus)
+		})
+		if checksum != 3475 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_export_state_json: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_invite_to_channel(uniffiStatus)
+		})
+		if checksum != 51991 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_invite_to_channel: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_channels(uniffiStatus)
+		})
+		if checksum != 12276 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_channels: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_handles(uniffiStatus)
+		})
+		if checksum != 17015 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_handles: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_reset_keys(uniffiStatus)
+		})
+		if checksum != 28788 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_reset_keys: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_roll_keys(uniffiStatus)
+		})
+		if checksum != 23793 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_roll_keys: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_share_status(uniffiStatus)
+		})
+		if checksum != 10053 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_share_status: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_update_channels(uniffiStatus)
+		})
+		if checksum != 25555 {
+			// If this happens try cleaning and rebuilding your project
+			panic("rustpushgo: uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_update_channels: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -1118,6 +1811,30 @@ func (FfiConverterInt64) Read(reader io.Reader) int64 {
 type FfiDestroyerInt64 struct{}
 
 func (FfiDestroyerInt64) Destroy(_ int64) {}
+
+type FfiConverterFloat64 struct{}
+
+var FfiConverterFloat64INSTANCE = FfiConverterFloat64{}
+
+func (FfiConverterFloat64) Lower(value float64) C.double {
+	return C.double(value)
+}
+
+func (FfiConverterFloat64) Write(writer io.Writer, value float64) {
+	writeFloat64(writer, value)
+}
+
+func (FfiConverterFloat64) Lift(value C.double) float64 {
+	return float64(value)
+}
+
+func (FfiConverterFloat64) Read(reader io.Reader) float64 {
+	return readFloat64(reader)
+}
+
+type FfiDestroyerFloat64 struct{}
+
+func (FfiDestroyerFloat64) Destroy(_ float64) {}
 
 type FfiConverterBool struct{}
 
@@ -1603,6 +2320,81 @@ func (_self *Client) DeleteCloudMessages(messageIds []string) error {
 		})
 }
 
+func (_self *Client) FindmyFriendsImport(daemon bool, url string) error {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_findmy_friends_import(
+				_pointer, FfiConverterBoolINSTANCE.Lower(daemon), rustBufferToC(FfiConverterStringINSTANCE.Lower(url)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) FindmyFriendsRefreshJson(daemon bool) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_findmy_friends_refresh_json(
+				_pointer, FfiConverterBoolINSTANCE.Lower(daemon),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) FindmyPhoneRefreshJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_findmy_phone_refresh_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) GetContactsUrl() (*string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -1653,6 +2445,56 @@ func (_self *Client) GetDsid() (*string, error) {
 		})
 }
 
+func (_self *Client) GetFacetimeClient() (*WrappedFaceTimeClient, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_get_facetime_client(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedFaceTimeClientINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) GetFindmyClient() (*WrappedFindMyClient, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_get_findmy_client(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedFindMyClientINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) GetHandles() []string {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -1699,6 +2541,81 @@ func (_self *Client) GetIcloudAuthHeaders() (*map[string]string, error) {
 		FfiConverterOptionalMapStringStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
 			// freeFunc
 			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) GetPasswordsClient() (*WrappedPasswordsClient, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_get_passwords_client(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedPasswordsClientINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) GetSharedstreamsClient() (*WrappedSharedStreamsClient, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_get_sharedstreams_client(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedSharedStreamsClientINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) GetStatuskitClient() (*WrappedStatusKitClient, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_get_statuskit_client(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedStatusKitClientINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
 		})
 }
 
@@ -1926,6 +2843,31 @@ func (_self *Client) SendEdit(conversation WrappedConversation, targetUuid strin
 		})
 }
 
+func (_self *Client) SendErrorMessage(conversation WrappedConversation, forUuid string, errorStatus uint64, statusStr string, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_error_message(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(forUuid)), FfiConverterUint64INSTANCE.Lower(errorStatus), rustBufferToC(FfiConverterStringINSTANCE.Lower(statusStr)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) SendIconChange(conversation WrappedConversation, photoData []byte, groupVersion uint64, handle string) (string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -1976,6 +2918,31 @@ func (_self *Client) SendIconClear(conversation WrappedConversation, groupVersio
 		})
 }
 
+func (_self *Client) SendMarkUnread(conversation WrappedConversation, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_mark_unread(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) SendMessage(conversation WrappedConversation, text string, html *string, handle string, replyGuid *string, replyPart *string, scheduledMs *uint64) (string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -1984,6 +2951,31 @@ func (_self *Client) SendMessage(conversation WrappedConversation, text string, 
 			// rustFutureFunc
 			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_message(
 				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(text)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(html)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(replyGuid)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(replyPart)), rustBufferToC(FfiConverterOptionalUint64INSTANCE.Lower(scheduledMs)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendMessageReadOnDevice(conversation WrappedConversation, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_message_read_on_device(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
 				status,
 			))
 		},
@@ -2026,6 +3018,31 @@ func (_self *Client) SendMoveToRecycleBin(conversation WrappedConversation, hand
 		})
 }
 
+func (_self *Client) SendNotifyAnyways(conversation WrappedConversation, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_notify_anyways(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) SendPeerCacheInvalidate(conversation WrappedConversation, handle string) error {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -2048,6 +3065,56 @@ func (_self *Client) SendPeerCacheInvalidate(conversation WrappedConversation, h
 		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
 			// freeFunc
 			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendPermanentDeleteChat(conversation WrappedConversation, chatGuid string, isScheduled bool, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_permanent_delete_chat(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(chatGuid)), FfiConverterBoolINSTANCE.Lower(isScheduled), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendPermanentDeleteMessages(conversation WrappedConversation, messageUuids []string, isScheduled bool, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_permanent_delete_messages(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(messageUuids)), FfiConverterBoolINSTANCE.Lower(isScheduled), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
 		})
 }
 
@@ -2126,6 +3193,106 @@ func (_self *Client) SendRenameGroup(conversation WrappedConversation, newName s
 		})
 }
 
+func (_self *Client) SendSetTranscriptBackground(conversation WrappedConversation, groupVersion uint64, imageData *[]byte, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_set_transcript_background(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), FfiConverterUint64INSTANCE.Lower(groupVersion), rustBufferToC(FfiConverterOptionalBytesINSTANCE.Lower(imageData)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendShareProfile(conversation WrappedConversation, cloudKitRecordKey string, cloudKitDecryptionRecordKey []byte, lowResWallpaperTag *[]byte, wallpaperTag *[]byte, messageTag *[]byte, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_share_profile(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(cloudKitRecordKey)), rustBufferToC(FfiConverterBytesINSTANCE.Lower(cloudKitDecryptionRecordKey)), rustBufferToC(FfiConverterOptionalBytesINSTANCE.Lower(lowResWallpaperTag)), rustBufferToC(FfiConverterOptionalBytesINSTANCE.Lower(wallpaperTag)), rustBufferToC(FfiConverterOptionalBytesINSTANCE.Lower(messageTag)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendSmsActivation(conversation WrappedConversation, enable bool, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_sms_activation(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), FfiConverterBoolINSTANCE.Lower(enable), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendSmsConfirmSent(conversation WrappedConversation, smsStatus bool, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_sms_confirm_sent(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), FfiConverterBoolINSTANCE.Lower(smsStatus), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) SendTapback(conversation WrappedConversation, targetUuid string, targetPart uint64, reaction uint32, emoji *string, remove bool, handle string) (string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -2176,6 +3343,31 @@ func (_self *Client) SendTyping(conversation WrappedConversation, typing bool, h
 		})
 }
 
+func (_self *Client) SendTypingWithApp(conversation WrappedConversation, typing bool, handle string, bundleId string, icon []byte) error {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_typing_with_app(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), FfiConverterBoolINSTANCE.Lower(typing), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)), rustBufferToC(FfiConverterStringINSTANCE.Lower(bundleId)), rustBufferToC(FfiConverterBytesINSTANCE.Lower(icon)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
 func (_self *Client) SendUnschedule(conversation WrappedConversation, handle string) (string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Client")
 	defer _self.ffiObject.decrementPointer()
@@ -2209,6 +3401,81 @@ func (_self *Client) SendUnsend(conversation WrappedConversation, targetUuid str
 			// rustFutureFunc
 			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_unsend(
 				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(targetUuid)), FfiConverterUint64INSTANCE.Lower(editPart), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendUpdateExtension(conversation WrappedConversation, forUuid string, extension WrappedStickerExtension, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_update_extension(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterStringINSTANCE.Lower(forUuid)), rustBufferToC(FfiConverterTypeWrappedStickerExtensionINSTANCE.Lower(extension)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendUpdateProfile(conversation WrappedConversation, profile *WrappedShareProfileData, shareContacts bool, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_update_profile(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterOptionalTypeWrappedShareProfileDataINSTANCE.Lower(profile)), FfiConverterBoolINSTANCE.Lower(shareContacts), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *Client) SendUpdateProfileSharing(conversation WrappedConversation, sharedDismissed []string, sharedAll []string, version uint64, handle string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Client")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_client_send_update_profile_sharing(
+				_pointer, rustBufferToC(FfiConverterTypeWrappedConversationINSTANCE.Lower(conversation)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(sharedDismissed)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(sharedAll)), FfiConverterUint64INSTANCE.Lower(version), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
 				status,
 			))
 		},
@@ -2457,10 +3724,25 @@ type WrappedApsConnection struct {
 func (_self *WrappedApsConnection) State() *WrappedApsState {
 	_pointer := _self.ffiObject.incrementPointer("*WrappedApsConnection")
 	defer _self.ffiObject.decrementPointer()
-	return FfiConverterWrappedAPSStateINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_rustpushgo_fn_method_wrappedapsconnection_state(
-			_pointer, _uniffiStatus)
-	}))
+	return uniffiRustCallAsyncWithResult(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedapsconnection_state(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_pointer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) unsafe.Pointer {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_pointer(unsafe.Pointer(handle), status)
+		},
+		FfiConverterWrappedAPSStateINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_pointer(unsafe.Pointer(rustFuture), status)
+		})
 }
 
 func (object *WrappedApsConnection) Destroy() {
@@ -2567,6 +3849,576 @@ func (c FfiConverterWrappedAPSState) Write(writer io.Writer, value *WrappedApsSt
 type FfiDestroyerWrappedApsState struct{}
 
 func (_ FfiDestroyerWrappedApsState) Destroy(value *WrappedApsState) {
+	value.Destroy()
+}
+
+type WrappedFaceTimeClient struct {
+	ffiObject FfiObject
+}
+
+func (_self *WrappedFaceTimeClient) AddMembers(sessionId string, handles []string, letmein bool, toMembers *[]string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_add_members(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(sessionId)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(handles)), FfiConverterBoolINSTANCE.Lower(letmein), rustBufferToC(FfiConverterOptionalSequenceStringINSTANCE.Lower(toMembers)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) ClearLinks() error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_clear_links(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) CreateSession(groupId string, handle string, participants []string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_create_session(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(groupId)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(participants)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) DeleteLink(pseud string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_delete_link(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(pseud)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) ExportStateJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_export_state_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) GetLinkForUsage(handle string, usage string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_get_link_for_usage(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)), rustBufferToC(FfiConverterStringINSTANCE.Lower(usage)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) GetSessionLink(guid string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_get_session_link(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(guid)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) ListDelegatedLetmeinRequests() []WrappedLetMeInRequest {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithResult(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_list_delegated_letmein_requests(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterSequenceTypeWrappedLetMeInRequestINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) RemoveMembers(sessionId string, handles []string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_remove_members(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(sessionId)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(handles)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) RespondDelegatedLetmein(delegationUuid string, approvedGroup *string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_respond_delegated_letmein(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(delegationUuid)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(approvedGroup)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) Ring(sessionId string, targets []string, letmein bool) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_ring(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(sessionId)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(targets)), FfiConverterBoolINSTANCE.Lower(letmein),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFaceTimeClient) UseLinkFor(oldUsage string, usage string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfacetimeclient_use_link_for(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(oldUsage)), rustBufferToC(FfiConverterStringINSTANCE.Lower(usage)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (object *WrappedFaceTimeClient) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterWrappedFaceTimeClient struct{}
+
+var FfiConverterWrappedFaceTimeClientINSTANCE = FfiConverterWrappedFaceTimeClient{}
+
+func (c FfiConverterWrappedFaceTimeClient) Lift(pointer unsafe.Pointer) *WrappedFaceTimeClient {
+	result := &WrappedFaceTimeClient{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_rustpushgo_fn_free_wrappedfacetimeclient(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*WrappedFaceTimeClient).Destroy)
+	return result
+}
+
+func (c FfiConverterWrappedFaceTimeClient) Read(reader io.Reader) *WrappedFaceTimeClient {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterWrappedFaceTimeClient) Lower(value *WrappedFaceTimeClient) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*WrappedFaceTimeClient")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterWrappedFaceTimeClient) Write(writer io.Writer, value *WrappedFaceTimeClient) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerWrappedFaceTimeClient struct{}
+
+func (_ FfiDestroyerWrappedFaceTimeClient) Destroy(value *WrappedFaceTimeClient) {
+	value.Destroy()
+}
+
+type WrappedFindMyClient struct {
+	ffiObject FfiObject
+}
+
+func (_self *WrappedFindMyClient) AcceptItemShare(circleId string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_accept_item_share(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(circleId)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) DeleteSharedItem(id string, removeBeacon bool) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_delete_shared_item(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(id)), FfiConverterBoolINSTANCE.Lower(removeBeacon),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) ExportStateBytes() ([]byte, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_export_state_bytes(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterBytesINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) ExportStateJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_export_state_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) SyncItemPositions() error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_sync_item_positions(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) SyncItems(fetchShares bool) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_sync_items(
+				_pointer, FfiConverterBoolINSTANCE.Lower(fetchShares),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedFindMyClient) UpdateBeaconName(associatedBeacon string, roleId int64, name string, emoji string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedfindmyclient_update_beacon_name(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(associatedBeacon)), FfiConverterInt64INSTANCE.Lower(roleId), rustBufferToC(FfiConverterStringINSTANCE.Lower(name)), rustBufferToC(FfiConverterStringINSTANCE.Lower(emoji)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (object *WrappedFindMyClient) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterWrappedFindMyClient struct{}
+
+var FfiConverterWrappedFindMyClientINSTANCE = FfiConverterWrappedFindMyClient{}
+
+func (c FfiConverterWrappedFindMyClient) Lift(pointer unsafe.Pointer) *WrappedFindMyClient {
+	result := &WrappedFindMyClient{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_rustpushgo_fn_free_wrappedfindmyclient(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*WrappedFindMyClient).Destroy)
+	return result
+}
+
+func (c FfiConverterWrappedFindMyClient) Read(reader io.Reader) *WrappedFindMyClient {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterWrappedFindMyClient) Lower(value *WrappedFindMyClient) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*WrappedFindMyClient")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterWrappedFindMyClient) Write(writer io.Writer, value *WrappedFindMyClient) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerWrappedFindMyClient struct{}
+
+func (_ FfiDestroyerWrappedFindMyClient) Destroy(value *WrappedFindMyClient) {
 	value.Destroy()
 }
 
@@ -2777,6 +4629,1042 @@ func (c FfiConverterWrappedOSConfig) Write(writer io.Writer, value *WrappedOsCon
 type FfiDestroyerWrappedOsConfig struct{}
 
 func (_ FfiDestroyerWrappedOsConfig) Destroy(value *WrappedOsConfig) {
+	value.Destroy()
+}
+
+type WrappedPasswordsClient struct {
+	ffiObject FfiObject
+}
+
+func (_self *WrappedPasswordsClient) AcceptInvite(inviteId string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_accept_invite(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(inviteId)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) CreateGroup(name string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_create_group(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(name)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) DeclineInvite(inviteId string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_decline_invite(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(inviteId)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) DeletePasswordRawEntry(id string, group *string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_delete_password_raw_entry(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(id)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(group)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) ExportStateJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_export_state_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) GetPasswordSiteCounts(site string) WrappedPasswordSiteCounts {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithResult(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_get_password_site_counts(
+			_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(site)),
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterTypeWrappedPasswordSiteCountsINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) InviteUser(groupId string, handle string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_invite_user(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(groupId)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) ListPasswordRawEntryRefs() []WrappedPasswordEntryRef {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithResult(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_list_password_raw_entry_refs(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterSequenceTypeWrappedPasswordEntryRefINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) QueryHandle(handle string) (bool, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_query_handle(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_i8(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) C.int8_t {
+			// completeFunc
+			return C.ffi_rustpushgo_rust_future_complete_i8(unsafe.Pointer(handle), status)
+		},
+		FfiConverterBoolINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_i8(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) RemoveGroup(id string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_remove_group(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(id)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) RemoveUser(groupId string, handle string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_remove_user(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(groupId)), rustBufferToC(FfiConverterStringINSTANCE.Lower(handle)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) RenameGroup(id string, newName string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_rename_group(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(id)), rustBufferToC(FfiConverterStringINSTANCE.Lower(newName)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) SyncPasswords() error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_sync_passwords(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedPasswordsClient) UpsertPasswordRawEntry(id string, site string, account string, secretData []byte, group *string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedpasswordsclient_upsert_password_raw_entry(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(id)), rustBufferToC(FfiConverterStringINSTANCE.Lower(site)), rustBufferToC(FfiConverterStringINSTANCE.Lower(account)), rustBufferToC(FfiConverterBytesINSTANCE.Lower(secretData)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(group)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (object *WrappedPasswordsClient) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterWrappedPasswordsClient struct{}
+
+var FfiConverterWrappedPasswordsClientINSTANCE = FfiConverterWrappedPasswordsClient{}
+
+func (c FfiConverterWrappedPasswordsClient) Lift(pointer unsafe.Pointer) *WrappedPasswordsClient {
+	result := &WrappedPasswordsClient{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_rustpushgo_fn_free_wrappedpasswordsclient(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*WrappedPasswordsClient).Destroy)
+	return result
+}
+
+func (c FfiConverterWrappedPasswordsClient) Read(reader io.Reader) *WrappedPasswordsClient {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterWrappedPasswordsClient) Lower(value *WrappedPasswordsClient) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*WrappedPasswordsClient")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterWrappedPasswordsClient) Write(writer io.Writer, value *WrappedPasswordsClient) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerWrappedPasswordsClient struct{}
+
+func (_ FfiDestroyerWrappedPasswordsClient) Destroy(value *WrappedPasswordsClient) {
+	value.Destroy()
+}
+
+type WrappedSharedStreamsClient struct {
+	ffiObject FfiObject
+}
+
+func (_self *WrappedSharedStreamsClient) CreateAssetFromBytes(album string, filename string, data []byte, width uint64, height uint64, utiType string, videoType *string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_create_asset_from_bytes(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)), rustBufferToC(FfiConverterStringINSTANCE.Lower(filename)), rustBufferToC(FfiConverterBytesINSTANCE.Lower(data)), FfiConverterUint64INSTANCE.Lower(width), FfiConverterUint64INSTANCE.Lower(height), rustBufferToC(FfiConverterStringINSTANCE.Lower(utiType)), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(videoType)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) DeleteAssets(album string, assets []string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_delete_assets(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(assets)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) DownloadFileBytes(checksumHex string, token string, url string) ([]byte, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_download_file_bytes(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(checksumHex)), rustBufferToC(FfiConverterStringINSTANCE.Lower(token)), rustBufferToC(FfiConverterStringINSTANCE.Lower(url)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterBytesINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) ExportStateJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_export_state_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) GetAlbumSummary(album string) ([]string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_album_summary(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterSequenceStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) GetAssetsJson(album string, assets []string) (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_assets_json(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)), rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(assets)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) GetChanges() ([]string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_changes(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterSequenceStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) ListAlbumIds() []string {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithResult(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_list_album_ids(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterSequenceStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) Subscribe(album string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_subscribe(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) SubscribeToken(token string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_subscribe_token(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(token)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedSharedStreamsClient) Unsubscribe(album string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_unsubscribe(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(album)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (object *WrappedSharedStreamsClient) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterWrappedSharedStreamsClient struct{}
+
+var FfiConverterWrappedSharedStreamsClientINSTANCE = FfiConverterWrappedSharedStreamsClient{}
+
+func (c FfiConverterWrappedSharedStreamsClient) Lift(pointer unsafe.Pointer) *WrappedSharedStreamsClient {
+	result := &WrappedSharedStreamsClient{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_rustpushgo_fn_free_wrappedsharedstreamsclient(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*WrappedSharedStreamsClient).Destroy)
+	return result
+}
+
+func (c FfiConverterWrappedSharedStreamsClient) Read(reader io.Reader) *WrappedSharedStreamsClient {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterWrappedSharedStreamsClient) Lower(value *WrappedSharedStreamsClient) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*WrappedSharedStreamsClient")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterWrappedSharedStreamsClient) Write(writer io.Writer, value *WrappedSharedStreamsClient) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerWrappedSharedStreamsClient struct{}
+
+func (_ FfiDestroyerWrappedSharedStreamsClient) Destroy(value *WrappedSharedStreamsClient) {
+	value.Destroy()
+}
+
+type WrappedStatusKitClient struct {
+	ffiObject FfiObject
+}
+
+func (_self *WrappedStatusKitClient) ClearInterestTokens() {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	uniffiRustCallAsync(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_clear_interest_tokens(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) ConfigureAps() error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_configure_aps(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) EnsureChannel() error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_ensure_channel(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) ExportStateJson() (string, error) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithErrorAndResult(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_export_state_json(
+				_pointer,
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_rust_buffer(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) RustBufferI {
+			// completeFunc
+			return rustBufferFromC(C.ffi_rustpushgo_rust_future_complete_rust_buffer(unsafe.Pointer(handle), status))
+		},
+		FfiConverterStringINSTANCE.Lift, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_rust_buffer(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) InviteToChannel(senderHandle string, handles []WrappedStatusKitInviteHandle) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_invite_to_channel(
+				_pointer, rustBufferToC(FfiConverterStringINSTANCE.Lower(senderHandle)), rustBufferToC(FfiConverterSequenceTypeWrappedStatusKitInviteHandleINSTANCE.Lower(handles)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) RequestChannels(channels []WrappedApsChannelIdentifier) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	uniffiRustCallAsync(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_request_channels(
+			_pointer, rustBufferToC(FfiConverterSequenceTypeWrappedAPSChannelIdentifierINSTANCE.Lower(channels)),
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) RequestHandles(handles []string) {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	uniffiRustCallAsync(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_request_handles(
+			_pointer, rustBufferToC(FfiConverterSequenceStringINSTANCE.Lower(handles)),
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) ResetKeys() {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	uniffiRustCallAsync(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_reset_keys(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) RollKeys() {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	uniffiRustCallAsync(func(status *C.RustCallStatus) *C.void {
+		// rustFutureFunc
+		return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_roll_keys(
+			_pointer,
+			status,
+		))
+	},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) ShareStatus(active bool, mode *string) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_share_status(
+				_pointer, FfiConverterBoolINSTANCE.Lower(active), rustBufferToC(FfiConverterOptionalStringINSTANCE.Lower(mode)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (_self *WrappedStatusKitClient) UpdateChannels(channels []WrappedApsChannelIdentifier) error {
+	_pointer := _self.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer _self.ffiObject.decrementPointer()
+	return uniffiRustCallAsyncWithError(
+		FfiConverterTypeWrappedError{}, func(status *C.RustCallStatus) *C.void {
+			// rustFutureFunc
+			return (*C.void)(C.uniffi_rustpushgo_fn_method_wrappedstatuskitclient_update_channels(
+				_pointer, rustBufferToC(FfiConverterSequenceTypeWrappedAPSChannelIdentifierINSTANCE.Lower(channels)),
+				status,
+			))
+		},
+		func(handle *C.void, ptr unsafe.Pointer, status *C.RustCallStatus) {
+			// pollFunc
+			C.ffi_rustpushgo_rust_future_poll_void(unsafe.Pointer(handle), ptr, status)
+		},
+		func(handle *C.void, status *C.RustCallStatus) {
+			// completeFunc
+			C.ffi_rustpushgo_rust_future_complete_void(unsafe.Pointer(handle), status)
+		},
+		func(bool) {}, func(rustFuture *C.void, status *C.RustCallStatus) {
+			// freeFunc
+			C.ffi_rustpushgo_rust_future_free_void(unsafe.Pointer(rustFuture), status)
+		})
+}
+
+func (object *WrappedStatusKitClient) Destroy() {
+	runtime.SetFinalizer(object, nil)
+	object.ffiObject.destroy()
+}
+
+type FfiConverterWrappedStatusKitClient struct{}
+
+var FfiConverterWrappedStatusKitClientINSTANCE = FfiConverterWrappedStatusKitClient{}
+
+func (c FfiConverterWrappedStatusKitClient) Lift(pointer unsafe.Pointer) *WrappedStatusKitClient {
+	result := &WrappedStatusKitClient{
+		newFfiObject(
+			pointer,
+			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
+				C.uniffi_rustpushgo_fn_free_wrappedstatuskitclient(pointer, status)
+			}),
+	}
+	runtime.SetFinalizer(result, (*WrappedStatusKitClient).Destroy)
+	return result
+}
+
+func (c FfiConverterWrappedStatusKitClient) Read(reader io.Reader) *WrappedStatusKitClient {
+	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+}
+
+func (c FfiConverterWrappedStatusKitClient) Lower(value *WrappedStatusKitClient) unsafe.Pointer {
+	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
+	// because the pointer will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked pointer.
+	pointer := value.ffiObject.incrementPointer("*WrappedStatusKitClient")
+	defer value.ffiObject.decrementPointer()
+	return pointer
+}
+
+func (c FfiConverterWrappedStatusKitClient) Write(writer io.Writer, value *WrappedStatusKitClient) {
+	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+}
+
+type FfiDestroyerWrappedStatusKitClient struct{}
+
+func (_ FfiDestroyerWrappedStatusKitClient) Destroy(value *WrappedStatusKitClient) {
 	value.Destroy()
 }
 
@@ -3181,6 +6069,46 @@ func (c FfiConverterTypeIDSUsersWithIdentityRecord) Write(writer io.Writer, valu
 type FfiDestroyerTypeIdsUsersWithIdentityRecord struct{}
 
 func (_ FfiDestroyerTypeIdsUsersWithIdentityRecord) Destroy(value IdsUsersWithIdentityRecord) {
+	value.Destroy()
+}
+
+type WrappedApsChannelIdentifier struct {
+	Topic string
+	Id    []byte
+}
+
+func (r *WrappedApsChannelIdentifier) Destroy() {
+	FfiDestroyerString{}.Destroy(r.Topic)
+	FfiDestroyerBytes{}.Destroy(r.Id)
+}
+
+type FfiConverterTypeWrappedAPSChannelIdentifier struct{}
+
+var FfiConverterTypeWrappedAPSChannelIdentifierINSTANCE = FfiConverterTypeWrappedAPSChannelIdentifier{}
+
+func (c FfiConverterTypeWrappedAPSChannelIdentifier) Lift(rb RustBufferI) WrappedApsChannelIdentifier {
+	return LiftFromRustBuffer[WrappedApsChannelIdentifier](c, rb)
+}
+
+func (c FfiConverterTypeWrappedAPSChannelIdentifier) Read(reader io.Reader) WrappedApsChannelIdentifier {
+	return WrappedApsChannelIdentifier{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterBytesINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedAPSChannelIdentifier) Lower(value WrappedApsChannelIdentifier) RustBuffer {
+	return LowerIntoRustBuffer[WrappedApsChannelIdentifier](c, value)
+}
+
+func (c FfiConverterTypeWrappedAPSChannelIdentifier) Write(writer io.Writer, value WrappedApsChannelIdentifier) {
+	FfiConverterStringINSTANCE.Write(writer, value.Topic)
+	FfiConverterBytesINSTANCE.Write(writer, value.Id)
+}
+
+type FfiDestroyerTypeWrappedApsChannelIdentifier struct{}
+
+func (_ FfiDestroyerTypeWrappedApsChannelIdentifier) Destroy(value WrappedApsChannelIdentifier) {
 	value.Destroy()
 }
 
@@ -3676,76 +6604,140 @@ func (_ FfiDestroyerTypeWrappedConversation) Destroy(value WrappedConversation) 
 	value.Destroy()
 }
 
+type WrappedLetMeInRequest struct {
+	DelegationUuid string
+	Pseud          string
+	Requestor      string
+	Nickname       *string
+	Usage          *string
+}
+
+func (r *WrappedLetMeInRequest) Destroy() {
+	FfiDestroyerString{}.Destroy(r.DelegationUuid)
+	FfiDestroyerString{}.Destroy(r.Pseud)
+	FfiDestroyerString{}.Destroy(r.Requestor)
+	FfiDestroyerOptionalString{}.Destroy(r.Nickname)
+	FfiDestroyerOptionalString{}.Destroy(r.Usage)
+}
+
+type FfiConverterTypeWrappedLetMeInRequest struct{}
+
+var FfiConverterTypeWrappedLetMeInRequestINSTANCE = FfiConverterTypeWrappedLetMeInRequest{}
+
+func (c FfiConverterTypeWrappedLetMeInRequest) Lift(rb RustBufferI) WrappedLetMeInRequest {
+	return LiftFromRustBuffer[WrappedLetMeInRequest](c, rb)
+}
+
+func (c FfiConverterTypeWrappedLetMeInRequest) Read(reader io.Reader) WrappedLetMeInRequest {
+	return WrappedLetMeInRequest{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedLetMeInRequest) Lower(value WrappedLetMeInRequest) RustBuffer {
+	return LowerIntoRustBuffer[WrappedLetMeInRequest](c, value)
+}
+
+func (c FfiConverterTypeWrappedLetMeInRequest) Write(writer io.Writer, value WrappedLetMeInRequest) {
+	FfiConverterStringINSTANCE.Write(writer, value.DelegationUuid)
+	FfiConverterStringINSTANCE.Write(writer, value.Pseud)
+	FfiConverterStringINSTANCE.Write(writer, value.Requestor)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.Nickname)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.Usage)
+}
+
+type FfiDestroyerTypeWrappedLetMeInRequest struct{}
+
+func (_ FfiDestroyerTypeWrappedLetMeInRequest) Destroy(value WrappedLetMeInRequest) {
+	value.Destroy()
+}
+
 type WrappedMessage struct {
-	Uuid                      string
-	Sender                    *string
-	Text                      *string
-	Subject                   *string
-	Participants              []string
-	GroupName                 *string
-	TimestampMs               uint64
-	IsSms                     bool
-	IsTapback                 bool
-	TapbackType               *uint32
-	TapbackTargetUuid         *string
-	TapbackTargetPart         *uint64
-	TapbackEmoji              *string
-	TapbackRemove             bool
-	IsEdit                    bool
-	EditTargetUuid            *string
-	EditPart                  *uint64
-	EditNewText               *string
-	IsUnsend                  bool
-	UnsendTargetUuid          *string
-	UnsendEditPart            *uint64
-	IsRename                  bool
-	NewChatName               *string
-	IsParticipantChange       bool
-	NewParticipants           []string
-	Attachments               []WrappedAttachment
-	ReplyGuid                 *string
-	ReplyPart                 *string
-	IsTyping                  bool
-	IsReadReceipt             bool
-	IsDelivered               bool
-	IsError                   bool
-	ErrorForUuid              *string
-	ErrorStatus               *uint64
-	ErrorStatusStr            *string
-	IsPeerCacheInvalidate     bool
-	SendDelivered             bool
-	SenderGuid                *string
-	IsMoveToRecycleBin        bool
-	IsPermanentDelete         bool
-	IsRecoverChat             bool
-	DeleteChatParticipants    []string
-	DeleteChatGroupId         *string
-	DeleteChatGuid            *string
-	DeleteMessageUuids        []string
-	IsStoredMessage           bool
-	IsIconChange              bool
-	GroupPhotoCleared         bool
-	IconChangePhotoData       *[]byte
-	Html                      *string
-	IsVoice                   bool
-	Effect                    *string
-	ScheduledMs               *uint64
-	IsSmsActivation           *bool
-	IsSmsConfirmSent          *bool
-	IsMarkUnread              bool
-	IsMessageReadOnDevice     bool
-	IsUnschedule              bool
-	IsUpdateExtension         bool
-	UpdateExtensionForUuid    *string
-	IsUpdateProfileSharing    bool
-	IsNotifyAnyways           bool
-	IsSetTranscriptBackground bool
-	StickerData               *[]byte
-	StickerMime               *string
-	IsShareProfile            bool
-	ShareProfileRecordKey     *string
-	ShareProfileDecryptionKey *[]byte
-	ShareProfileHasPoster     bool
+	Uuid                          string
+	Sender                        *string
+	Text                          *string
+	Subject                       *string
+	Participants                  []string
+	GroupName                     *string
+	TimestampMs                   uint64
+	IsSms                         bool
+	IsTapback                     bool
+	TapbackType                   *uint32
+	TapbackTargetUuid             *string
+	TapbackTargetPart             *uint64
+	TapbackEmoji                  *string
+	TapbackRemove                 bool
+	IsEdit                        bool
+	EditTargetUuid                *string
+	EditPart                      *uint64
+	EditNewText                   *string
+	IsUnsend                      bool
+	UnsendTargetUuid              *string
+	UnsendEditPart                *uint64
+	IsRename                      bool
+	NewChatName                   *string
+	IsParticipantChange           bool
+	NewParticipants               []string
+	Attachments                   []WrappedAttachment
+	ReplyGuid                     *string
+	ReplyPart                     *string
+	IsTyping                      bool
+	TypingAppBundleId             *string
+	TypingAppIcon                 *[]byte
+	IsReadReceipt                 bool
+	IsDelivered                   bool
+	IsError                       bool
+	ErrorForUuid                  *string
+	ErrorStatus                   *uint64
+	ErrorStatusStr                *string
+	IsPeerCacheInvalidate         bool
+	SendDelivered                 bool
+	SenderGuid                    *string
+	IsMoveToRecycleBin            bool
+	IsPermanentDelete             bool
+	IsRecoverChat                 bool
+	DeleteChatParticipants        []string
+	DeleteChatGroupId             *string
+	DeleteChatGuid                *string
+	DeleteMessageUuids            []string
+	IsStoredMessage               bool
+	IsIconChange                  bool
+	GroupPhotoCleared             bool
+	IconChangePhotoData           *[]byte
+	Html                          *string
+	IsVoice                       bool
+	Effect                        *string
+	ScheduledMs                   *uint64
+	IsSmsActivation               *bool
+	IsSmsConfirmSent              *bool
+	IsMarkUnread                  bool
+	IsMessageReadOnDevice         bool
+	IsUnschedule                  bool
+	IsUpdateExtension             bool
+	UpdateExtensionForUuid        *string
+	IsUpdateProfileSharing        bool
+	UpdateProfileSharingDismissed []string
+	UpdateProfileSharingAll       []string
+	UpdateProfileSharingVersion   *uint64
+	IsUpdateProfile               bool
+	UpdateProfileShareContacts    *bool
+	IsNotifyAnyways               bool
+	IsSetTranscriptBackground     bool
+	TranscriptBackgroundRemove    *bool
+	TranscriptBackgroundChatId    *string
+	TranscriptBackgroundObjectId  *string
+	TranscriptBackgroundUrl       *string
+	TranscriptBackgroundFileSize  *uint64
+	StickerData                   *[]byte
+	StickerMime                   *string
+	IsShareProfile                bool
+	ShareProfileRecordKey         *string
+	ShareProfileDecryptionKey     *[]byte
+	ShareProfileHasPoster         bool
 }
 
 func (r *WrappedMessage) Destroy() {
@@ -3778,6 +6770,8 @@ func (r *WrappedMessage) Destroy() {
 	FfiDestroyerOptionalString{}.Destroy(r.ReplyGuid)
 	FfiDestroyerOptionalString{}.Destroy(r.ReplyPart)
 	FfiDestroyerBool{}.Destroy(r.IsTyping)
+	FfiDestroyerOptionalString{}.Destroy(r.TypingAppBundleId)
+	FfiDestroyerOptionalBytes{}.Destroy(r.TypingAppIcon)
 	FfiDestroyerBool{}.Destroy(r.IsReadReceipt)
 	FfiDestroyerBool{}.Destroy(r.IsDelivered)
 	FfiDestroyerBool{}.Destroy(r.IsError)
@@ -3810,8 +6804,18 @@ func (r *WrappedMessage) Destroy() {
 	FfiDestroyerBool{}.Destroy(r.IsUpdateExtension)
 	FfiDestroyerOptionalString{}.Destroy(r.UpdateExtensionForUuid)
 	FfiDestroyerBool{}.Destroy(r.IsUpdateProfileSharing)
+	FfiDestroyerSequenceString{}.Destroy(r.UpdateProfileSharingDismissed)
+	FfiDestroyerSequenceString{}.Destroy(r.UpdateProfileSharingAll)
+	FfiDestroyerOptionalUint64{}.Destroy(r.UpdateProfileSharingVersion)
+	FfiDestroyerBool{}.Destroy(r.IsUpdateProfile)
+	FfiDestroyerOptionalBool{}.Destroy(r.UpdateProfileShareContacts)
 	FfiDestroyerBool{}.Destroy(r.IsNotifyAnyways)
 	FfiDestroyerBool{}.Destroy(r.IsSetTranscriptBackground)
+	FfiDestroyerOptionalBool{}.Destroy(r.TranscriptBackgroundRemove)
+	FfiDestroyerOptionalString{}.Destroy(r.TranscriptBackgroundChatId)
+	FfiDestroyerOptionalString{}.Destroy(r.TranscriptBackgroundObjectId)
+	FfiDestroyerOptionalString{}.Destroy(r.TranscriptBackgroundUrl)
+	FfiDestroyerOptionalUint64{}.Destroy(r.TranscriptBackgroundFileSize)
 	FfiDestroyerOptionalBytes{}.Destroy(r.StickerData)
 	FfiDestroyerOptionalString{}.Destroy(r.StickerMime)
 	FfiDestroyerBool{}.Destroy(r.IsShareProfile)
@@ -3859,6 +6863,8 @@ func (c FfiConverterTypeWrappedMessage) Read(reader io.Reader) WrappedMessage {
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalBytesINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
@@ -3891,8 +6897,18 @@ func (c FfiConverterTypeWrappedMessage) Read(reader io.Reader) WrappedMessage {
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterSequenceStringINSTANCE.Read(reader),
+		FfiConverterSequenceStringINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalBoolINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
 		FfiConverterOptionalBytesINSTANCE.Read(reader),
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
@@ -3936,6 +6952,8 @@ func (c FfiConverterTypeWrappedMessage) Write(writer io.Writer, value WrappedMes
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.ReplyGuid)
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.ReplyPart)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsTyping)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.TypingAppBundleId)
+	FfiConverterOptionalBytesINSTANCE.Write(writer, value.TypingAppIcon)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsReadReceipt)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsDelivered)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsError)
@@ -3968,8 +6986,18 @@ func (c FfiConverterTypeWrappedMessage) Write(writer io.Writer, value WrappedMes
 	FfiConverterBoolINSTANCE.Write(writer, value.IsUpdateExtension)
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.UpdateExtensionForUuid)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsUpdateProfileSharing)
+	FfiConverterSequenceStringINSTANCE.Write(writer, value.UpdateProfileSharingDismissed)
+	FfiConverterSequenceStringINSTANCE.Write(writer, value.UpdateProfileSharingAll)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.UpdateProfileSharingVersion)
+	FfiConverterBoolINSTANCE.Write(writer, value.IsUpdateProfile)
+	FfiConverterOptionalBoolINSTANCE.Write(writer, value.UpdateProfileShareContacts)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsNotifyAnyways)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsSetTranscriptBackground)
+	FfiConverterOptionalBoolINSTANCE.Write(writer, value.TranscriptBackgroundRemove)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.TranscriptBackgroundChatId)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.TranscriptBackgroundObjectId)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.TranscriptBackgroundUrl)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.TranscriptBackgroundFileSize)
 	FfiConverterOptionalBytesINSTANCE.Write(writer, value.StickerData)
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.StickerMime)
 	FfiConverterBoolINSTANCE.Write(writer, value.IsShareProfile)
@@ -3981,6 +7009,266 @@ func (c FfiConverterTypeWrappedMessage) Write(writer io.Writer, value WrappedMes
 type FfiDestroyerTypeWrappedMessage struct{}
 
 func (_ FfiDestroyerTypeWrappedMessage) Destroy(value WrappedMessage) {
+	value.Destroy()
+}
+
+type WrappedPasswordEntryRef struct {
+	Id    string
+	Group *string
+}
+
+func (r *WrappedPasswordEntryRef) Destroy() {
+	FfiDestroyerString{}.Destroy(r.Id)
+	FfiDestroyerOptionalString{}.Destroy(r.Group)
+}
+
+type FfiConverterTypeWrappedPasswordEntryRef struct{}
+
+var FfiConverterTypeWrappedPasswordEntryRefINSTANCE = FfiConverterTypeWrappedPasswordEntryRef{}
+
+func (c FfiConverterTypeWrappedPasswordEntryRef) Lift(rb RustBufferI) WrappedPasswordEntryRef {
+	return LiftFromRustBuffer[WrappedPasswordEntryRef](c, rb)
+}
+
+func (c FfiConverterTypeWrappedPasswordEntryRef) Read(reader io.Reader) WrappedPasswordEntryRef {
+	return WrappedPasswordEntryRef{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedPasswordEntryRef) Lower(value WrappedPasswordEntryRef) RustBuffer {
+	return LowerIntoRustBuffer[WrappedPasswordEntryRef](c, value)
+}
+
+func (c FfiConverterTypeWrappedPasswordEntryRef) Write(writer io.Writer, value WrappedPasswordEntryRef) {
+	FfiConverterStringINSTANCE.Write(writer, value.Id)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.Group)
+}
+
+type FfiDestroyerTypeWrappedPasswordEntryRef struct{}
+
+func (_ FfiDestroyerTypeWrappedPasswordEntryRef) Destroy(value WrappedPasswordEntryRef) {
+	value.Destroy()
+}
+
+type WrappedPasswordSiteCounts struct {
+	WebsiteMetaCount  uint64
+	PasswordCount     uint64
+	PasswordMetaCount uint64
+	PasskeyCount      uint64
+}
+
+func (r *WrappedPasswordSiteCounts) Destroy() {
+	FfiDestroyerUint64{}.Destroy(r.WebsiteMetaCount)
+	FfiDestroyerUint64{}.Destroy(r.PasswordCount)
+	FfiDestroyerUint64{}.Destroy(r.PasswordMetaCount)
+	FfiDestroyerUint64{}.Destroy(r.PasskeyCount)
+}
+
+type FfiConverterTypeWrappedPasswordSiteCounts struct{}
+
+var FfiConverterTypeWrappedPasswordSiteCountsINSTANCE = FfiConverterTypeWrappedPasswordSiteCounts{}
+
+func (c FfiConverterTypeWrappedPasswordSiteCounts) Lift(rb RustBufferI) WrappedPasswordSiteCounts {
+	return LiftFromRustBuffer[WrappedPasswordSiteCounts](c, rb)
+}
+
+func (c FfiConverterTypeWrappedPasswordSiteCounts) Read(reader io.Reader) WrappedPasswordSiteCounts {
+	return WrappedPasswordSiteCounts{
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedPasswordSiteCounts) Lower(value WrappedPasswordSiteCounts) RustBuffer {
+	return LowerIntoRustBuffer[WrappedPasswordSiteCounts](c, value)
+}
+
+func (c FfiConverterTypeWrappedPasswordSiteCounts) Write(writer io.Writer, value WrappedPasswordSiteCounts) {
+	FfiConverterUint64INSTANCE.Write(writer, value.WebsiteMetaCount)
+	FfiConverterUint64INSTANCE.Write(writer, value.PasswordCount)
+	FfiConverterUint64INSTANCE.Write(writer, value.PasswordMetaCount)
+	FfiConverterUint64INSTANCE.Write(writer, value.PasskeyCount)
+}
+
+type FfiDestroyerTypeWrappedPasswordSiteCounts struct{}
+
+func (_ FfiDestroyerTypeWrappedPasswordSiteCounts) Destroy(value WrappedPasswordSiteCounts) {
+	value.Destroy()
+}
+
+type WrappedShareProfileData struct {
+	CloudKitRecordKey           string
+	CloudKitDecryptionRecordKey []byte
+	LowResWallpaperTag          *[]byte
+	WallpaperTag                *[]byte
+	MessageTag                  *[]byte
+}
+
+func (r *WrappedShareProfileData) Destroy() {
+	FfiDestroyerString{}.Destroy(r.CloudKitRecordKey)
+	FfiDestroyerBytes{}.Destroy(r.CloudKitDecryptionRecordKey)
+	FfiDestroyerOptionalBytes{}.Destroy(r.LowResWallpaperTag)
+	FfiDestroyerOptionalBytes{}.Destroy(r.WallpaperTag)
+	FfiDestroyerOptionalBytes{}.Destroy(r.MessageTag)
+}
+
+type FfiConverterTypeWrappedShareProfileData struct{}
+
+var FfiConverterTypeWrappedShareProfileDataINSTANCE = FfiConverterTypeWrappedShareProfileData{}
+
+func (c FfiConverterTypeWrappedShareProfileData) Lift(rb RustBufferI) WrappedShareProfileData {
+	return LiftFromRustBuffer[WrappedShareProfileData](c, rb)
+}
+
+func (c FfiConverterTypeWrappedShareProfileData) Read(reader io.Reader) WrappedShareProfileData {
+	return WrappedShareProfileData{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterBytesINSTANCE.Read(reader),
+		FfiConverterOptionalBytesINSTANCE.Read(reader),
+		FfiConverterOptionalBytesINSTANCE.Read(reader),
+		FfiConverterOptionalBytesINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedShareProfileData) Lower(value WrappedShareProfileData) RustBuffer {
+	return LowerIntoRustBuffer[WrappedShareProfileData](c, value)
+}
+
+func (c FfiConverterTypeWrappedShareProfileData) Write(writer io.Writer, value WrappedShareProfileData) {
+	FfiConverterStringINSTANCE.Write(writer, value.CloudKitRecordKey)
+	FfiConverterBytesINSTANCE.Write(writer, value.CloudKitDecryptionRecordKey)
+	FfiConverterOptionalBytesINSTANCE.Write(writer, value.LowResWallpaperTag)
+	FfiConverterOptionalBytesINSTANCE.Write(writer, value.WallpaperTag)
+	FfiConverterOptionalBytesINSTANCE.Write(writer, value.MessageTag)
+}
+
+type FfiDestroyerTypeWrappedShareProfileData struct{}
+
+func (_ FfiDestroyerTypeWrappedShareProfileData) Destroy(value WrappedShareProfileData) {
+	value.Destroy()
+}
+
+type WrappedStatusKitInviteHandle struct {
+	Handle       string
+	AllowedModes []string
+}
+
+func (r *WrappedStatusKitInviteHandle) Destroy() {
+	FfiDestroyerString{}.Destroy(r.Handle)
+	FfiDestroyerSequenceString{}.Destroy(r.AllowedModes)
+}
+
+type FfiConverterTypeWrappedStatusKitInviteHandle struct{}
+
+var FfiConverterTypeWrappedStatusKitInviteHandleINSTANCE = FfiConverterTypeWrappedStatusKitInviteHandle{}
+
+func (c FfiConverterTypeWrappedStatusKitInviteHandle) Lift(rb RustBufferI) WrappedStatusKitInviteHandle {
+	return LiftFromRustBuffer[WrappedStatusKitInviteHandle](c, rb)
+}
+
+func (c FfiConverterTypeWrappedStatusKitInviteHandle) Read(reader io.Reader) WrappedStatusKitInviteHandle {
+	return WrappedStatusKitInviteHandle{
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterSequenceStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedStatusKitInviteHandle) Lower(value WrappedStatusKitInviteHandle) RustBuffer {
+	return LowerIntoRustBuffer[WrappedStatusKitInviteHandle](c, value)
+}
+
+func (c FfiConverterTypeWrappedStatusKitInviteHandle) Write(writer io.Writer, value WrappedStatusKitInviteHandle) {
+	FfiConverterStringINSTANCE.Write(writer, value.Handle)
+	FfiConverterSequenceStringINSTANCE.Write(writer, value.AllowedModes)
+}
+
+type FfiDestroyerTypeWrappedStatusKitInviteHandle struct{}
+
+func (_ FfiDestroyerTypeWrappedStatusKitInviteHandle) Destroy(value WrappedStatusKitInviteHandle) {
+	value.Destroy()
+}
+
+type WrappedStickerExtension struct {
+	MsgWidth    float64
+	Rotation    float64
+	Sai         uint64
+	Scale       float64
+	Sli         uint64
+	NormalizedX float64
+	NormalizedY float64
+	Version     uint64
+	Hash        string
+	Safi        uint64
+	EffectType  int64
+	StickerId   string
+}
+
+func (r *WrappedStickerExtension) Destroy() {
+	FfiDestroyerFloat64{}.Destroy(r.MsgWidth)
+	FfiDestroyerFloat64{}.Destroy(r.Rotation)
+	FfiDestroyerUint64{}.Destroy(r.Sai)
+	FfiDestroyerFloat64{}.Destroy(r.Scale)
+	FfiDestroyerUint64{}.Destroy(r.Sli)
+	FfiDestroyerFloat64{}.Destroy(r.NormalizedX)
+	FfiDestroyerFloat64{}.Destroy(r.NormalizedY)
+	FfiDestroyerUint64{}.Destroy(r.Version)
+	FfiDestroyerString{}.Destroy(r.Hash)
+	FfiDestroyerUint64{}.Destroy(r.Safi)
+	FfiDestroyerInt64{}.Destroy(r.EffectType)
+	FfiDestroyerString{}.Destroy(r.StickerId)
+}
+
+type FfiConverterTypeWrappedStickerExtension struct{}
+
+var FfiConverterTypeWrappedStickerExtensionINSTANCE = FfiConverterTypeWrappedStickerExtension{}
+
+func (c FfiConverterTypeWrappedStickerExtension) Lift(rb RustBufferI) WrappedStickerExtension {
+	return LiftFromRustBuffer[WrappedStickerExtension](c, rb)
+}
+
+func (c FfiConverterTypeWrappedStickerExtension) Read(reader io.Reader) WrappedStickerExtension {
+	return WrappedStickerExtension{
+		FfiConverterFloat64INSTANCE.Read(reader),
+		FfiConverterFloat64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterFloat64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterFloat64INSTANCE.Read(reader),
+		FfiConverterFloat64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterStringINSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterInt64INSTANCE.Read(reader),
+		FfiConverterStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTypeWrappedStickerExtension) Lower(value WrappedStickerExtension) RustBuffer {
+	return LowerIntoRustBuffer[WrappedStickerExtension](c, value)
+}
+
+func (c FfiConverterTypeWrappedStickerExtension) Write(writer io.Writer, value WrappedStickerExtension) {
+	FfiConverterFloat64INSTANCE.Write(writer, value.MsgWidth)
+	FfiConverterFloat64INSTANCE.Write(writer, value.Rotation)
+	FfiConverterUint64INSTANCE.Write(writer, value.Sai)
+	FfiConverterFloat64INSTANCE.Write(writer, value.Scale)
+	FfiConverterUint64INSTANCE.Write(writer, value.Sli)
+	FfiConverterFloat64INSTANCE.Write(writer, value.NormalizedX)
+	FfiConverterFloat64INSTANCE.Write(writer, value.NormalizedY)
+	FfiConverterUint64INSTANCE.Write(writer, value.Version)
+	FfiConverterStringINSTANCE.Write(writer, value.Hash)
+	FfiConverterUint64INSTANCE.Write(writer, value.Safi)
+	FfiConverterInt64INSTANCE.Write(writer, value.EffectType)
+	FfiConverterStringINSTANCE.Write(writer, value.StickerId)
+}
+
+type FfiDestroyerTypeWrappedStickerExtension struct{}
+
+func (_ FfiDestroyerTypeWrappedStickerExtension) Destroy(value WrappedStickerExtension) {
 	value.Destroy()
 }
 
@@ -4032,14 +7320,14 @@ type FfiConverterTypeWrappedError struct{}
 var FfiConverterTypeWrappedErrorINSTANCE = FfiConverterTypeWrappedError{}
 
 func (c FfiConverterTypeWrappedError) Lift(eb RustBufferI) error {
-	return LiftFromRustBuffer[*WrappedError](c, eb)
+	return LiftFromRustBuffer[error](c, eb)
 }
 
 func (c FfiConverterTypeWrappedError) Lower(value *WrappedError) RustBuffer {
 	return LowerIntoRustBuffer[*WrappedError](c, value)
 }
 
-func (c FfiConverterTypeWrappedError) Read(reader io.Reader) *WrappedError {
+func (c FfiConverterTypeWrappedError) Read(reader io.Reader) error {
 	errorID := readUint32(reader)
 
 	switch errorID {
@@ -4074,38 +7362,48 @@ const (
 )
 
 type concurrentHandleMap[T any] struct {
-	handles       map[uint64]T
+	leftMap       map[uint64]*T
+	rightMap      map[*T]uint64
 	currentHandle uint64
 	lock          sync.RWMutex
 }
 
 func newConcurrentHandleMap[T any]() *concurrentHandleMap[T] {
 	return &concurrentHandleMap[T]{
-		handles: map[uint64]T{},
+		leftMap:  map[uint64]*T{},
+		rightMap: map[*T]uint64{},
 	}
 }
 
-func (cm *concurrentHandleMap[T]) insert(obj T) uint64 {
+func (cm *concurrentHandleMap[T]) insert(obj *T) uint64 {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
+	if existingHandle, ok := cm.rightMap[obj]; ok {
+		return existingHandle
+	}
 	cm.currentHandle = cm.currentHandle + 1
-	cm.handles[cm.currentHandle] = obj
+	cm.leftMap[cm.currentHandle] = obj
+	cm.rightMap[obj] = cm.currentHandle
 	return cm.currentHandle
 }
 
-func (cm *concurrentHandleMap[T]) remove(handle uint64) {
+func (cm *concurrentHandleMap[T]) remove(handle uint64) bool {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
-	delete(cm.handles, handle)
+	if val, ok := cm.leftMap[handle]; ok {
+		delete(cm.leftMap, handle)
+		delete(cm.rightMap, val)
+	}
+	return false
 }
 
-func (cm *concurrentHandleMap[T]) tryGet(handle uint64) (T, bool) {
+func (cm *concurrentHandleMap[T]) tryGet(handle uint64) (*T, bool) {
 	cm.lock.RLock()
 	defer cm.lock.RUnlock()
 
-	val, ok := cm.handles[handle]
+	val, ok := cm.leftMap[handle]
 	return val, ok
 }
 
@@ -4123,7 +7421,7 @@ func (c *FfiConverterCallbackInterface[CallbackInterface]) Lift(handle uint64) C
 	if !ok {
 		panic(fmt.Errorf("no callback in handle map: %d", handle))
 	}
-	return val
+	return *val
 }
 
 func (c *FfiConverterCallbackInterface[CallbackInterface]) Read(reader io.Reader) CallbackInterface {
@@ -4131,7 +7429,7 @@ func (c *FfiConverterCallbackInterface[CallbackInterface]) Read(reader io.Reader
 }
 
 func (c *FfiConverterCallbackInterface[CallbackInterface]) Lower(value CallbackInterface) C.uint64_t {
-	return C.uint64_t(c.handleMap.insert(value))
+	return C.uint64_t(c.handleMap.insert(&value))
 }
 
 func (c *FfiConverterCallbackInterface[CallbackInterface]) Write(writer io.Writer, value CallbackInterface) {
@@ -4595,6 +7893,80 @@ func (_ FfiDestroyerOptionalTypeAccountPersistData) Destroy(value *AccountPersis
 	}
 }
 
+type FfiConverterOptionalTypeWrappedShareProfileData struct{}
+
+var FfiConverterOptionalTypeWrappedShareProfileDataINSTANCE = FfiConverterOptionalTypeWrappedShareProfileData{}
+
+func (c FfiConverterOptionalTypeWrappedShareProfileData) Lift(rb RustBufferI) *WrappedShareProfileData {
+	return LiftFromRustBuffer[*WrappedShareProfileData](c, rb)
+}
+
+func (_ FfiConverterOptionalTypeWrappedShareProfileData) Read(reader io.Reader) *WrappedShareProfileData {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterTypeWrappedShareProfileDataINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalTypeWrappedShareProfileData) Lower(value *WrappedShareProfileData) RustBuffer {
+	return LowerIntoRustBuffer[*WrappedShareProfileData](c, value)
+}
+
+func (_ FfiConverterOptionalTypeWrappedShareProfileData) Write(writer io.Writer, value *WrappedShareProfileData) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterTypeWrappedShareProfileDataINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalTypeWrappedShareProfileData struct{}
+
+func (_ FfiDestroyerOptionalTypeWrappedShareProfileData) Destroy(value *WrappedShareProfileData) {
+	if value != nil {
+		FfiDestroyerTypeWrappedShareProfileData{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalSequenceString struct{}
+
+var FfiConverterOptionalSequenceStringINSTANCE = FfiConverterOptionalSequenceString{}
+
+func (c FfiConverterOptionalSequenceString) Lift(rb RustBufferI) *[]string {
+	return LiftFromRustBuffer[*[]string](c, rb)
+}
+
+func (_ FfiConverterOptionalSequenceString) Read(reader io.Reader) *[]string {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterSequenceStringINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalSequenceString) Lower(value *[]string) RustBuffer {
+	return LowerIntoRustBuffer[*[]string](c, value)
+}
+
+func (_ FfiConverterOptionalSequenceString) Write(writer io.Writer, value *[]string) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterSequenceStringINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalSequenceString struct{}
+
+func (_ FfiDestroyerOptionalSequenceString) Destroy(value *[]string) {
+	if value != nil {
+		FfiDestroyerSequenceString{}.Destroy(*value)
+	}
+}
+
 type FfiConverterOptionalMapStringString struct{}
 
 var FfiConverterOptionalMapStringStringINSTANCE = FfiConverterOptionalMapStringString{}
@@ -4715,6 +8087,49 @@ type FfiDestroyerSequenceTypeEscrowDeviceInfo struct{}
 func (FfiDestroyerSequenceTypeEscrowDeviceInfo) Destroy(sequence []EscrowDeviceInfo) {
 	for _, value := range sequence {
 		FfiDestroyerTypeEscrowDeviceInfo{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceTypeWrappedAPSChannelIdentifier struct{}
+
+var FfiConverterSequenceTypeWrappedAPSChannelIdentifierINSTANCE = FfiConverterSequenceTypeWrappedAPSChannelIdentifier{}
+
+func (c FfiConverterSequenceTypeWrappedAPSChannelIdentifier) Lift(rb RustBufferI) []WrappedApsChannelIdentifier {
+	return LiftFromRustBuffer[[]WrappedApsChannelIdentifier](c, rb)
+}
+
+func (c FfiConverterSequenceTypeWrappedAPSChannelIdentifier) Read(reader io.Reader) []WrappedApsChannelIdentifier {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]WrappedApsChannelIdentifier, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterTypeWrappedAPSChannelIdentifierINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceTypeWrappedAPSChannelIdentifier) Lower(value []WrappedApsChannelIdentifier) RustBuffer {
+	return LowerIntoRustBuffer[[]WrappedApsChannelIdentifier](c, value)
+}
+
+func (c FfiConverterSequenceTypeWrappedAPSChannelIdentifier) Write(writer io.Writer, value []WrappedApsChannelIdentifier) {
+	if len(value) > math.MaxInt32 {
+		panic("[]WrappedApsChannelIdentifier is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterTypeWrappedAPSChannelIdentifierINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceTypeWrappedApsChannelIdentifier struct{}
+
+func (FfiDestroyerSequenceTypeWrappedApsChannelIdentifier) Destroy(sequence []WrappedApsChannelIdentifier) {
+	for _, value := range sequence {
+		FfiDestroyerTypeWrappedApsChannelIdentifier{}.Destroy(value)
 	}
 }
 
@@ -4890,6 +8305,135 @@ func (FfiDestroyerSequenceTypeWrappedCloudSyncMessage) Destroy(sequence []Wrappe
 	}
 }
 
+type FfiConverterSequenceTypeWrappedLetMeInRequest struct{}
+
+var FfiConverterSequenceTypeWrappedLetMeInRequestINSTANCE = FfiConverterSequenceTypeWrappedLetMeInRequest{}
+
+func (c FfiConverterSequenceTypeWrappedLetMeInRequest) Lift(rb RustBufferI) []WrappedLetMeInRequest {
+	return LiftFromRustBuffer[[]WrappedLetMeInRequest](c, rb)
+}
+
+func (c FfiConverterSequenceTypeWrappedLetMeInRequest) Read(reader io.Reader) []WrappedLetMeInRequest {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]WrappedLetMeInRequest, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterTypeWrappedLetMeInRequestINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceTypeWrappedLetMeInRequest) Lower(value []WrappedLetMeInRequest) RustBuffer {
+	return LowerIntoRustBuffer[[]WrappedLetMeInRequest](c, value)
+}
+
+func (c FfiConverterSequenceTypeWrappedLetMeInRequest) Write(writer io.Writer, value []WrappedLetMeInRequest) {
+	if len(value) > math.MaxInt32 {
+		panic("[]WrappedLetMeInRequest is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterTypeWrappedLetMeInRequestINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceTypeWrappedLetMeInRequest struct{}
+
+func (FfiDestroyerSequenceTypeWrappedLetMeInRequest) Destroy(sequence []WrappedLetMeInRequest) {
+	for _, value := range sequence {
+		FfiDestroyerTypeWrappedLetMeInRequest{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceTypeWrappedPasswordEntryRef struct{}
+
+var FfiConverterSequenceTypeWrappedPasswordEntryRefINSTANCE = FfiConverterSequenceTypeWrappedPasswordEntryRef{}
+
+func (c FfiConverterSequenceTypeWrappedPasswordEntryRef) Lift(rb RustBufferI) []WrappedPasswordEntryRef {
+	return LiftFromRustBuffer[[]WrappedPasswordEntryRef](c, rb)
+}
+
+func (c FfiConverterSequenceTypeWrappedPasswordEntryRef) Read(reader io.Reader) []WrappedPasswordEntryRef {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]WrappedPasswordEntryRef, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterTypeWrappedPasswordEntryRefINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceTypeWrappedPasswordEntryRef) Lower(value []WrappedPasswordEntryRef) RustBuffer {
+	return LowerIntoRustBuffer[[]WrappedPasswordEntryRef](c, value)
+}
+
+func (c FfiConverterSequenceTypeWrappedPasswordEntryRef) Write(writer io.Writer, value []WrappedPasswordEntryRef) {
+	if len(value) > math.MaxInt32 {
+		panic("[]WrappedPasswordEntryRef is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterTypeWrappedPasswordEntryRefINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceTypeWrappedPasswordEntryRef struct{}
+
+func (FfiDestroyerSequenceTypeWrappedPasswordEntryRef) Destroy(sequence []WrappedPasswordEntryRef) {
+	for _, value := range sequence {
+		FfiDestroyerTypeWrappedPasswordEntryRef{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceTypeWrappedStatusKitInviteHandle struct{}
+
+var FfiConverterSequenceTypeWrappedStatusKitInviteHandleINSTANCE = FfiConverterSequenceTypeWrappedStatusKitInviteHandle{}
+
+func (c FfiConverterSequenceTypeWrappedStatusKitInviteHandle) Lift(rb RustBufferI) []WrappedStatusKitInviteHandle {
+	return LiftFromRustBuffer[[]WrappedStatusKitInviteHandle](c, rb)
+}
+
+func (c FfiConverterSequenceTypeWrappedStatusKitInviteHandle) Read(reader io.Reader) []WrappedStatusKitInviteHandle {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]WrappedStatusKitInviteHandle, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterTypeWrappedStatusKitInviteHandleINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceTypeWrappedStatusKitInviteHandle) Lower(value []WrappedStatusKitInviteHandle) RustBuffer {
+	return LowerIntoRustBuffer[[]WrappedStatusKitInviteHandle](c, value)
+}
+
+func (c FfiConverterSequenceTypeWrappedStatusKitInviteHandle) Write(writer io.Writer, value []WrappedStatusKitInviteHandle) {
+	if len(value) > math.MaxInt32 {
+		panic("[]WrappedStatusKitInviteHandle is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterTypeWrappedStatusKitInviteHandleINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceTypeWrappedStatusKitInviteHandle struct{}
+
+func (FfiDestroyerSequenceTypeWrappedStatusKitInviteHandle) Destroy(sequence []WrappedStatusKitInviteHandle) {
+	for _, value := range sequence {
+		FfiDestroyerTypeWrappedStatusKitInviteHandle{}.Destroy(value)
+	}
+}
+
 type FfiConverterMapStringString struct{}
 
 var FfiConverterMapStringStringINSTANCE = FfiConverterMapStringString{}
@@ -4935,8 +8479,8 @@ func (_ FfiDestroyerMapStringString) Destroy(mapValue map[string]string) {
 }
 
 const (
-	uniffiRustFuturePollReady      int8 = 0
-	uniffiRustFuturePollMaybeReady int8 = 1
+	uniffiRustFuturePollReady      C.int8_t = 0
+	uniffiRustFuturePollMaybeReady C.int8_t = 1
 )
 
 func uniffiRustCallAsync(
@@ -5043,8 +8587,8 @@ func uniffiRustCallAsyncInner(
 	pollFunc func(*C.void, unsafe.Pointer, *C.RustCallStatus),
 	freeFunc func(*C.void, *C.RustCallStatus),
 ) (*C.void, error) {
-	pollResult := int8(-1)
-	waiter := make(chan int8, 1)
+	pollResult := C.int8_t(-1)
+	waiter := make(chan C.int8_t, 1)
 	chanHandle := cgo.NewHandle(waiter)
 
 	rustFuture, err := rustCallWithError(converter, func(status *C.RustCallStatus) *C.void {
@@ -5078,8 +8622,8 @@ func uniffiRustCallAsyncInner(
 //export uniffiFutureContinuationCallbackrustpushgo
 func uniffiFutureContinuationCallbackrustpushgo(ptr unsafe.Pointer, pollResult C.int8_t) {
 	doneHandle := *(*cgo.Handle)(ptr)
-	done := doneHandle.Value().((chan int8))
-	done <- int8(pollResult)
+	done := doneHandle.Value().((chan C.int8_t))
+	done <- pollResult
 }
 
 func uniffiInitContinuationCallback() {

--- a/pkg/rustpushgo/rustpushgo.h
+++ b/pkg/rustpushgo/rustpushgo.h
@@ -145,6 +145,24 @@ void* uniffi_rustpushgo_fn_method_client_delete_cloud_messages(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_findmy_friends_import(
+	void* ptr,
+	int8_t daemon,
+	RustBuffer url,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_findmy_friends_refresh_json(
+	void* ptr,
+	int8_t daemon,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_findmy_phone_refresh_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_get_contacts_url(
 	void* ptr,
 	RustCallStatus* out_status
@@ -155,12 +173,37 @@ void* uniffi_rustpushgo_fn_method_client_get_dsid(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_get_facetime_client(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_get_findmy_client(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_get_handles(
 	void* ptr,
 	RustCallStatus* out_status
 );
 
 void* uniffi_rustpushgo_fn_method_client_get_icloud_auth_headers(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_get_passwords_client(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_get_sharedstreams_client(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_get_statuskit_client(
 	void* ptr,
 	RustCallStatus* out_status
 );
@@ -237,6 +280,16 @@ void* uniffi_rustpushgo_fn_method_client_send_edit(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_error_message(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer for_uuid,
+	uint64_t error_status,
+	RustBuffer status_str,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_icon_change(
 	void* ptr,
 	RustBuffer conversation,
@@ -254,6 +307,13 @@ void* uniffi_rustpushgo_fn_method_client_send_icon_clear(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_mark_unread(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_message(
 	void* ptr,
 	RustBuffer conversation,
@@ -266,6 +326,13 @@ void* uniffi_rustpushgo_fn_method_client_send_message(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_message_read_on_device(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_move_to_recycle_bin(
 	void* ptr,
 	RustBuffer conversation,
@@ -274,9 +341,34 @@ void* uniffi_rustpushgo_fn_method_client_send_move_to_recycle_bin(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_notify_anyways(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_peer_cache_invalidate(
 	void* ptr,
 	RustBuffer conversation,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_permanent_delete_chat(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer chat_guid,
+	int8_t is_scheduled,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_permanent_delete_messages(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer message_uuids,
+	int8_t is_scheduled,
 	RustBuffer handle,
 	RustCallStatus* out_status
 );
@@ -305,6 +397,43 @@ void* uniffi_rustpushgo_fn_method_client_send_rename_group(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_set_transcript_background(
+	void* ptr,
+	RustBuffer conversation,
+	uint64_t group_version,
+	RustBuffer image_data,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_share_profile(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer cloud_kit_record_key,
+	RustBuffer cloud_kit_decryption_record_key,
+	RustBuffer low_res_wallpaper_tag,
+	RustBuffer wallpaper_tag,
+	RustBuffer message_tag,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_sms_activation(
+	void* ptr,
+	RustBuffer conversation,
+	int8_t enable,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_sms_confirm_sent(
+	void* ptr,
+	RustBuffer conversation,
+	int8_t sms_status,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_tapback(
 	void* ptr,
 	RustBuffer conversation,
@@ -325,6 +454,16 @@ void* uniffi_rustpushgo_fn_method_client_send_typing(
 	RustCallStatus* out_status
 );
 
+void* uniffi_rustpushgo_fn_method_client_send_typing_with_app(
+	void* ptr,
+	RustBuffer conversation,
+	int8_t typing,
+	RustBuffer handle,
+	RustBuffer bundle_id,
+	RustBuffer icon,
+	RustCallStatus* out_status
+);
+
 void* uniffi_rustpushgo_fn_method_client_send_unschedule(
 	void* ptr,
 	RustBuffer conversation,
@@ -337,6 +476,34 @@ void* uniffi_rustpushgo_fn_method_client_send_unsend(
 	RustBuffer conversation,
 	RustBuffer target_uuid,
 	uint64_t edit_part,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_update_extension(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer for_uuid,
+	RustBuffer extension,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_update_profile(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer profile,
+	int8_t share_contacts,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_client_send_update_profile_sharing(
+	void* ptr,
+	RustBuffer conversation,
+	RustBuffer shared_dismissed,
+	RustBuffer shared_all,
+	uint64_t version,
 	RustBuffer handle,
 	RustCallStatus* out_status
 );
@@ -408,6 +575,139 @@ RustBuffer uniffi_rustpushgo_fn_method_wrappedapsstate_to_string(
 	RustCallStatus* out_status
 );
 
+void uniffi_rustpushgo_fn_free_wrappedfacetimeclient(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_add_members(
+	void* ptr,
+	RustBuffer session_id,
+	RustBuffer handles,
+	int8_t letmein,
+	RustBuffer to_members,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_clear_links(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_create_session(
+	void* ptr,
+	RustBuffer group_id,
+	RustBuffer handle,
+	RustBuffer participants,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_delete_link(
+	void* ptr,
+	RustBuffer pseud,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_export_state_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_get_link_for_usage(
+	void* ptr,
+	RustBuffer handle,
+	RustBuffer usage,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_get_session_link(
+	void* ptr,
+	RustBuffer guid,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_list_delegated_letmein_requests(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_remove_members(
+	void* ptr,
+	RustBuffer session_id,
+	RustBuffer handles,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_respond_delegated_letmein(
+	void* ptr,
+	RustBuffer delegation_uuid,
+	RustBuffer approved_group,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_ring(
+	void* ptr,
+	RustBuffer session_id,
+	RustBuffer targets,
+	int8_t letmein,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfacetimeclient_use_link_for(
+	void* ptr,
+	RustBuffer old_usage,
+	RustBuffer usage,
+	RustCallStatus* out_status
+);
+
+void uniffi_rustpushgo_fn_free_wrappedfindmyclient(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_accept_item_share(
+	void* ptr,
+	RustBuffer circle_id,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_delete_shared_item(
+	void* ptr,
+	RustBuffer id,
+	int8_t remove_beacon,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_export_state_bytes(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_export_state_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_sync_item_positions(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_sync_items(
+	void* ptr,
+	int8_t fetch_shares,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedfindmyclient_update_beacon_name(
+	void* ptr,
+	RustBuffer associated_beacon,
+	int64_t role_id,
+	RustBuffer name,
+	RustBuffer emoji,
+	RustCallStatus* out_status
+);
+
 void uniffi_rustpushgo_fn_free_wrappedidsngmidentity(
 	void* ptr,
 	RustCallStatus* out_status
@@ -461,6 +761,245 @@ void uniffi_rustpushgo_fn_free_wrappedosconfig(
 
 RustBuffer uniffi_rustpushgo_fn_method_wrappedosconfig_get_device_id(
 	void* ptr,
+	RustCallStatus* out_status
+);
+
+void uniffi_rustpushgo_fn_free_wrappedpasswordsclient(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_accept_invite(
+	void* ptr,
+	RustBuffer invite_id,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_create_group(
+	void* ptr,
+	RustBuffer name,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_decline_invite(
+	void* ptr,
+	RustBuffer invite_id,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_delete_password_raw_entry(
+	void* ptr,
+	RustBuffer id,
+	RustBuffer group,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_export_state_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_get_password_site_counts(
+	void* ptr,
+	RustBuffer site,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_invite_user(
+	void* ptr,
+	RustBuffer group_id,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_list_password_raw_entry_refs(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_query_handle(
+	void* ptr,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_remove_group(
+	void* ptr,
+	RustBuffer id,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_remove_user(
+	void* ptr,
+	RustBuffer group_id,
+	RustBuffer handle,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_rename_group(
+	void* ptr,
+	RustBuffer id,
+	RustBuffer new_name,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_sync_passwords(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedpasswordsclient_upsert_password_raw_entry(
+	void* ptr,
+	RustBuffer id,
+	RustBuffer site,
+	RustBuffer account,
+	RustBuffer secret_data,
+	RustBuffer group,
+	RustCallStatus* out_status
+);
+
+void uniffi_rustpushgo_fn_free_wrappedsharedstreamsclient(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_create_asset_from_bytes(
+	void* ptr,
+	RustBuffer album,
+	RustBuffer filename,
+	RustBuffer data,
+	uint64_t width,
+	uint64_t height,
+	RustBuffer uti_type,
+	RustBuffer video_type,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_delete_assets(
+	void* ptr,
+	RustBuffer album,
+	RustBuffer assets,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_download_file_bytes(
+	void* ptr,
+	RustBuffer checksum_hex,
+	RustBuffer token,
+	RustBuffer url,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_export_state_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_album_summary(
+	void* ptr,
+	RustBuffer album,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_assets_json(
+	void* ptr,
+	RustBuffer album,
+	RustBuffer assets,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_get_changes(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_list_album_ids(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_subscribe(
+	void* ptr,
+	RustBuffer album,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_subscribe_token(
+	void* ptr,
+	RustBuffer token,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedsharedstreamsclient_unsubscribe(
+	void* ptr,
+	RustBuffer album,
+	RustCallStatus* out_status
+);
+
+void uniffi_rustpushgo_fn_free_wrappedstatuskitclient(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_clear_interest_tokens(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_configure_aps(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_ensure_channel(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_export_state_json(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_invite_to_channel(
+	void* ptr,
+	RustBuffer sender_handle,
+	RustBuffer handles,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_request_channels(
+	void* ptr,
+	RustBuffer channels,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_request_handles(
+	void* ptr,
+	RustBuffer handles,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_reset_keys(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_roll_keys(
+	void* ptr,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_share_status(
+	void* ptr,
+	int8_t active,
+	RustBuffer mode,
+	RustCallStatus* out_status
+);
+
+void* uniffi_rustpushgo_fn_method_wrappedstatuskitclient_update_channels(
+	void* ptr,
+	RustBuffer channels,
 	RustCallStatus* out_status
 );
 
@@ -965,6 +1504,18 @@ uint16_t uniffi_rustpushgo_checksum_method_client_delete_cloud_messages(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_findmy_friends_import(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_findmy_friends_refresh_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_findmy_phone_refresh_json(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_get_contacts_url(
 	RustCallStatus* out_status
 );
@@ -973,11 +1524,31 @@ uint16_t uniffi_rustpushgo_checksum_method_client_get_dsid(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_get_facetime_client(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_get_findmy_client(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_get_handles(
 	RustCallStatus* out_status
 );
 
 uint16_t uniffi_rustpushgo_checksum_method_client_get_icloud_auth_headers(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_get_passwords_client(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_get_sharedstreams_client(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_get_statuskit_client(
 	RustCallStatus* out_status
 );
 
@@ -1017,6 +1588,10 @@ uint16_t uniffi_rustpushgo_checksum_method_client_send_edit(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_send_error_message(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_send_icon_change(
 	RustCallStatus* out_status
 );
@@ -1025,7 +1600,15 @@ uint16_t uniffi_rustpushgo_checksum_method_client_send_icon_clear(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_send_mark_unread(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_send_message(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_message_read_on_device(
 	RustCallStatus* out_status
 );
 
@@ -1033,7 +1616,19 @@ uint16_t uniffi_rustpushgo_checksum_method_client_send_move_to_recycle_bin(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_send_notify_anyways(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_send_peer_cache_invalidate(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_permanent_delete_chat(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_permanent_delete_messages(
 	RustCallStatus* out_status
 );
 
@@ -1049,6 +1644,22 @@ uint16_t uniffi_rustpushgo_checksum_method_client_send_rename_group(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_send_set_transcript_background(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_share_profile(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_sms_activation(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_sms_confirm_sent(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_send_tapback(
 	RustCallStatus* out_status
 );
@@ -1057,11 +1668,27 @@ uint16_t uniffi_rustpushgo_checksum_method_client_send_typing(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_client_send_typing_with_app(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_client_send_unschedule(
 	RustCallStatus* out_status
 );
 
 uint16_t uniffi_rustpushgo_checksum_method_client_send_unsend(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_update_extension(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_update_profile(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_client_send_update_profile_sharing(
 	RustCallStatus* out_status
 );
 
@@ -1097,6 +1724,82 @@ uint16_t uniffi_rustpushgo_checksum_method_wrappedapsstate_to_string(
 	RustCallStatus* out_status
 );
 
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_add_members(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_clear_links(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_create_session(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_delete_link(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_export_state_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_link_for_usage(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_get_session_link(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_list_delegated_letmein_requests(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_remove_members(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_respond_delegated_letmein(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_ring(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfacetimeclient_use_link_for(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_accept_item_share(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_delete_shared_item(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_bytes(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_export_state_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_item_positions(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_sync_items(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedfindmyclient_update_beacon_name(
+	RustCallStatus* out_status
+);
+
 uint16_t uniffi_rustpushgo_checksum_method_wrappedidsngmidentity_to_string(
 	RustCallStatus* out_status
 );
@@ -1118,6 +1821,150 @@ uint16_t uniffi_rustpushgo_checksum_method_wrappedidsusers_validate_keystore(
 );
 
 uint16_t uniffi_rustpushgo_checksum_method_wrappedosconfig_get_device_id(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_accept_invite(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_create_group(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_decline_invite(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_delete_password_raw_entry(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_export_state_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_get_password_site_counts(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_invite_user(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_list_password_raw_entry_refs(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_query_handle(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_group(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_remove_user(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_rename_group(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_sync_passwords(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedpasswordsclient_upsert_password_raw_entry(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_create_asset_from_bytes(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_delete_assets(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_download_file_bytes(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_export_state_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_album_summary(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_assets_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_get_changes(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_list_album_ids(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_subscribe_token(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedsharedstreamsclient_unsubscribe(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_clear_interest_tokens(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_configure_aps(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_ensure_channel(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_export_state_json(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_invite_to_channel(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_channels(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_request_handles(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_reset_keys(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_roll_keys(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_share_status(
+	RustCallStatus* out_status
+);
+
+uint16_t uniffi_rustpushgo_checksum_method_wrappedstatuskitclient_update_channels(
 	RustCallStatus* out_status
 );
 

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -7,7 +7,7 @@ mod test_hwinfo;
 use std::{collections::HashMap, io::Cursor, path::PathBuf, str::FromStr, sync::Arc, time::Duration, sync::atomic::{AtomicU64, Ordering}};
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
-use icloud_auth::{AppleAccount, FetchedToken};
+use icloud_auth::AppleAccount;
 use keystore::{init_keystore, keystore, software::{NoEncryptor, SoftwareKeystore, SoftwareKeystoreState}};
 use log::{debug, error, info, warn};
 use rustpush::{
@@ -16,14 +16,15 @@ use rustpush::{
     IDSNGMIdentity, IDSUser, IMClient, LoginDelegate, MADRID_SERVICE, MMCSFile, Message,
     MessageInst, MessagePart, MessageParts, MessageType, MoveToRecycleBinMessage, NormalMessage, PermanentDeleteMessage,
     OperatedChat, OSConfig, ReactMessage, ReactMessageType, Reaction, RenameMessage,
-    ChangeParticipantMessage, IconChangeMessage, UnsendMessage,
+    ChangeParticipantMessage, IconChangeMessage, UnsendMessage, TypingApp,
     IndexedMessagePart, LinkMeta, LPLinkMetadata, RichLinkImageAttachmentSubstitute, NSURL,
     TextFlags, TextFormat, TextEffect,
-    ShareProfileMessage, SharedPoster,
+    ShareProfileMessage, SharedPoster, PartExtension, UpdateExtensionMessage, UpdateProfileMessage,
+    UpdateProfileSharingMessage, SetTranscriptBackgroundMessage,
     TokenProvider, MobileMeDelegateResponse,
     ScheduleMode,
     cloudkit::{ZoneDeleteOperation, CloudKitSession},
-    util::{base64_decode, encode_hex, ResourceState},
+    base64_decode, encode_hex, ResourceState,
 };
 use rustpush::cloudkit_proto::request_operation::header::IsolationLevel;
 use omnisette::default_provider;
@@ -61,11 +62,11 @@ pub struct WrappedAPSConnection {
     pub inner: rustpush::APSConnection,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl WrappedAPSConnection {
-    pub fn state(&self) -> Arc<WrappedAPSState> {
+    pub async fn state(&self) -> Arc<WrappedAPSState> {
         Arc::new(WrappedAPSState {
-            inner: Some(self.inner.state.blocking_read().clone()),
+            inner: Some(self.inner.state.read().await.clone()),
         })
     }
 }
@@ -449,7 +450,7 @@ async fn create_keychain_clients(
     let cloudkit_state = rustpush::cloudkit::CloudKitState::new(dsid.clone())
         .ok_or(WrappedError::GenericError { msg: "Failed to create CloudKitState".into() })?;
     let cloudkit = Arc::new(rustpush::cloudkit::CloudKitClient {
-        state: tokio::sync::RwLock::new(cloudkit_state),
+            state: rustpush::DebugRwLock::new(cloudkit_state),
         anisette: anisette.clone(),
         config: os_config.clone(),
         token_provider: token_provider.clone(),
@@ -479,7 +480,7 @@ async fn create_keychain_clients(
     let keychain = Arc::new(rustpush::keychain::KeychainClient {
         anisette: anisette.clone(),
         token_provider: token_provider.clone(),
-        state: tokio::sync::RwLock::new(keychain_state.expect("keychain state missing")),
+            state: rustpush::DebugRwLock::new(keychain_state.expect("keychain state missing")),
         config: os_config.clone(),
         update_state: Box::new(move |state| {
             if let Err(e) = plist::to_file_xml(&path_for_closure, state) {
@@ -788,7 +789,7 @@ pub async fn restore_token_provider(
     account.username = Some(username);
 
     // Restore hashed password
-    let hashed_password = rustpush::util::decode_hex(&hashed_password_hex)
+    let hashed_password = rustpush::decode_hex(&hashed_password_hex)
         .map_err(|e| WrappedError::GenericError { msg: format!("Invalid hashed_password hex: {}", e) })?;
     account.hashed_password = Some(hashed_password);
 
@@ -802,12 +803,12 @@ pub async fn restore_token_provider(
     // This forces get_token() to call login_email_pass() on first use,
     // which will obtain a fresh PET via SRP (no 2FA needed if the machine
     // is trusted via consistent anisette state).
-    account.tokens.insert("com.apple.gs.idms.pet".to_string(), icloud_auth::FetchedToken {
-        token: pet,
-        expiration: std::time::UNIX_EPOCH, // expired — forces auto-refresh on first use
-    });
+    account.tokens.insert(
+        "com.apple.gs.idms.pet".to_string(),
+        icloud_auth::FetchedToken::new(pet, std::time::UNIX_EPOCH), // expired — forces auto-refresh on first use
+    );
 
-    let account = Arc::new(tokio::sync::Mutex::new(account));
+    let account = Arc::new(rustpush::DebugMutex::new(account));
     let token_provider = TokenProvider::new(account, os_config);
 
     info!("Restored TokenProvider from persisted credentials");
@@ -866,6 +867,8 @@ pub struct WrappedMessage {
 
     // Typing
     pub is_typing: bool,
+    pub typing_app_bundle_id: Option<String>,
+    pub typing_app_icon: Option<Vec<u8>>,
 
     // Read receipt
     pub is_read_receipt: bool,
@@ -950,12 +953,24 @@ pub struct WrappedMessage {
 
     // Profile sharing state sync update.
     pub is_update_profile_sharing: bool,
+    pub update_profile_sharing_dismissed: Vec<String>,
+    pub update_profile_sharing_all: Vec<String>,
+    pub update_profile_sharing_version: Option<u64>,
+
+    // Profile update (share profile card and/or sharing preference).
+    pub is_update_profile: bool,
+    pub update_profile_share_contacts: Option<bool>,
 
     // "Notify anyway" control message.
     pub is_notify_anyways: bool,
 
     // Transcript background (conversation wallpaper) update.
     pub is_set_transcript_background: bool,
+    pub transcript_background_remove: Option<bool>,
+    pub transcript_background_chat_id: Option<String>,
+    pub transcript_background_object_id: Option<String>,
+    pub transcript_background_url: Option<String>,
+    pub transcript_background_file_size: Option<u64>,
 
     // Sticker data for sticker tapback reactions (tapback_type=7).
     pub sticker_data: Option<Vec<u8>>,
@@ -978,6 +993,66 @@ pub struct WrappedAttachment {
     pub inline_data: Option<Vec<u8>>,
     /// True for Live Photo attachments (Apple's "iris" flag).
     pub iris: bool,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedStickerExtension {
+    pub msg_width: f64,
+    pub rotation: f64,
+    pub sai: u64,
+    pub scale: f64,
+    pub sli: u64,
+    pub normalized_x: f64,
+    pub normalized_y: f64,
+    pub version: u64,
+    pub hash: String,
+    pub safi: u64,
+    pub effect_type: i64,
+    pub sticker_id: String,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedShareProfileData {
+    pub cloud_kit_record_key: String,
+    pub cloud_kit_decryption_record_key: Vec<u8>,
+    pub low_res_wallpaper_tag: Option<Vec<u8>>,
+    pub wallpaper_tag: Option<Vec<u8>>,
+    pub message_tag: Option<Vec<u8>>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedAPSChannelIdentifier {
+    pub topic: String,
+    pub id: Vec<u8>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedStatusKitInviteHandle {
+    pub handle: String,
+    pub allowed_modes: Vec<String>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedPasswordEntryRef {
+    pub id: String,
+    pub group: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedPasswordSiteCounts {
+    pub website_meta_count: u64,
+    pub password_count: u64,
+    pub password_meta_count: u64,
+    pub passkey_count: u64,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WrappedLetMeInRequest {
+    pub delegation_uuid: String,
+    pub pseud: String,
+    pub requestor: String,
+    pub nickname: Option<String>,
+    pub usage: Option<String>,
 }
 
 #[derive(uniffi::Record, Clone)]
@@ -1233,7 +1308,7 @@ impl std::io::Write for SharedWriter {
 /// The attributedBody is an NSAttributedString containing ranges with
 /// __kIMFileTransferGUIDAttributeName → attachment GUID.
 fn extract_attachment_guids_from_attributed_body(data: &[u8]) -> Vec<String> {
-    use rustpush::util::{coder_decode_flattened, NSAttributedString, StCollapsedValue};
+    use rustpush::{coder_decode_flattened, NSAttributedString, StCollapsedValue};
 
     let decoded = match std::panic::catch_unwind(|| {
         let flat = coder_decode_flattened(data);
@@ -1550,6 +1625,8 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
         reply_guid: None,
         reply_part: None,
         is_typing: false,
+        typing_app_bundle_id: None,
+        typing_app_icon: None,
         is_read_receipt: false,
         is_delivered: false,
         is_error: false,
@@ -1582,8 +1659,18 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
         is_update_extension: false,
         update_extension_for_uuid: None,
         is_update_profile_sharing: false,
+        update_profile_sharing_dismissed: vec![],
+        update_profile_sharing_all: vec![],
+        update_profile_sharing_version: None,
+        is_update_profile: false,
+        update_profile_share_contacts: None,
         is_notify_anyways: false,
         is_set_transcript_background: false,
+        transcript_background_remove: None,
+        transcript_background_chat_id: None,
+        transcript_background_object_id: None,
+        transcript_background_url: None,
+        transcript_background_file_size: None,
         sticker_data: None,
         sticker_mime: None,
         is_share_profile: false,
@@ -1620,7 +1707,7 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
 
             // Encode rich link as special attachments for the Go side
             if let Some(ref lm) = normal.link_meta {
-                let original_url: String = lm.data.original_url.clone().into();
+                let original_url: String = lm.data.original_url.clone().map(|u| u.into()).unwrap_or_default();
                 let url: String = lm.data.url.clone().map(|u| u.into()).unwrap_or_default();
                 let title = lm.data.title.clone().unwrap_or_default();
                 let summary = lm.data.summary.clone().unwrap_or_default();
@@ -1736,8 +1823,12 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
             w.is_participant_change = true;
             w.new_participants = change.new_participants.clone();
         }
-        Message::Typing(typing, _) => {
+        Message::Typing(typing, app) => {
             w.is_typing = *typing;
+            if let Some(app) = app {
+                w.typing_app_bundle_id = Some(app.bundle_id.clone());
+                w.typing_app_icon = Some(app.icon.clone());
+            }
         }
         Message::Read => {
             w.is_read_receipt = true;
@@ -1791,14 +1882,8 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
             w.is_update_extension = true;
             w.update_extension_for_uuid = Some(update.for_uuid.clone());
         }
-        Message::UpdateProfileSharing(_) => {
-            w.is_update_profile_sharing = true;
-        }
         Message::NotifyAnyways => {
             w.is_notify_anyways = true;
-        }
-        Message::SetTranscriptBackground(_) => {
-            w.is_set_transcript_background = true;
         }
         Message::ShareProfile(profile) => {
             w.is_share_profile = true;
@@ -1807,11 +1892,35 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
             w.share_profile_has_poster = profile.poster.is_some();
         }
         Message::UpdateProfile(update) => {
+            w.is_update_profile = true;
+            w.update_profile_share_contacts = Some(update.share_contacts);
             if let Some(profile) = &update.profile {
                 w.is_share_profile = true;
                 w.share_profile_record_key = Some(profile.cloud_kit_record_key.clone());
                 w.share_profile_decryption_key = Some(profile.cloud_kit_decryption_record_key.clone());
                 w.share_profile_has_poster = profile.poster.is_some();
+            }
+        }
+        Message::UpdateProfileSharing(update) => {
+            w.is_update_profile_sharing = true;
+            w.update_profile_sharing_dismissed = update.shared_dismissed.clone();
+            w.update_profile_sharing_all = update.shared_all.clone();
+            w.update_profile_sharing_version = Some(update.version);
+        }
+        Message::SetTranscriptBackground(update) => {
+            w.is_set_transcript_background = true;
+            match update {
+                SetTranscriptBackgroundMessage::Remove { chat_id, remove, .. } => {
+                    w.transcript_background_remove = Some(*remove);
+                    w.transcript_background_chat_id = chat_id.clone();
+                }
+                SetTranscriptBackgroundMessage::Set { chat_id, object_id, url, file_size, .. } => {
+                    w.transcript_background_remove = Some(false);
+                    w.transcript_background_chat_id = chat_id.clone();
+                    w.transcript_background_object_id = Some(object_id.clone());
+                    w.transcript_background_url = Some(url.clone());
+                    w.transcript_background_file_size = Some(*file_size as u64);
+                }
             }
         }
         _ => {}
@@ -1912,6 +2021,41 @@ fn resolve_xdg_data_dir() -> String {
     // Last resort — fall back to old relative path
     warn!("Could not determine HOME or XDG_DATA_HOME, using local state directory");
     "state".to_string()
+}
+
+fn subsystem_state_path(file_name: &str) -> String {
+    let xdg_dir = resolve_xdg_data_dir();
+    let _ = std::fs::create_dir_all(&xdg_dir);
+    format!("{}/{}", xdg_dir, file_name)
+}
+
+fn read_plist_state<T: serde::de::DeserializeOwned>(path: &str) -> Option<T> {
+    match std::fs::read(path) {
+        Ok(data) => match plist::from_bytes(&data) {
+            Ok(state) => Some(state),
+            Err(err) => {
+                warn!("Failed to parse state at {}: {}", path, err);
+                None
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            warn!("Failed to read state at {}: {}", path, err);
+            None
+        }
+    }
+}
+
+fn persist_plist_state<T: serde::Serialize>(path: &str, state: &T) {
+    if let Err(err) = plist::to_file_xml(path, state) {
+        warn!("Failed to persist state to {}: {}", path, err);
+    }
+}
+
+fn serialize_state_json<T: serde::Serialize>(state: &T) -> Result<String, WrappedError> {
+    serde_json::to_string(state).map_err(|err| WrappedError::GenericError {
+        msg: format!("Failed to serialize state: {}", err),
+    })
 }
 
 /// Create a local macOS config that reads hardware info from IOKit
@@ -2245,7 +2389,7 @@ impl LoginSession {
         let mut spd_bytes = Vec::new();
         plist::to_writer_binary(&mut spd_bytes, spd)
             .map_err(|e| WrappedError::GenericError { msg: format!("Failed to serialize SPD: {}", e) })?;
-        let spd_base64 = rustpush::util::base64_encode(&spd_bytes);
+        let spd_base64 = rustpush::base64_encode(&spd_bytes);
 
         let account_persist = AccountPersistData {
             username: self.username.clone(),
@@ -2333,7 +2477,7 @@ impl LoginSession {
         // so the first get_mme_token() doesn't need to re-fetch.
         let owned_account = guard.take()
             .ok_or(WrappedError::GenericError { msg: "Account already consumed".to_string() })?;
-        let account_arc = Arc::new(tokio::sync::Mutex::new(owned_account));
+        let account_arc = Arc::new(rustpush::DebugMutex::new(owned_account));
         let token_provider = TokenProvider::new(account_arc, os_config.clone());
 
         // Seed the MobileMe delegate so get_contacts_url() and get_mme_token()
@@ -2430,13 +2574,519 @@ async fn download_icon_change_photo(
 // ============================================================================
 
 #[derive(uniffi::Object)]
+pub struct WrappedFindMyClient {
+    inner: Arc<rustpush::findmy::FindMyClient<omnisette::DefaultAnisetteProvider>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl WrappedFindMyClient {
+    pub async fn export_state_json(&self) -> Result<String, WrappedError> {
+        let state = self.inner.state.state.lock().await;
+        serialize_state_json(&*state)
+    }
+
+    pub async fn export_state_bytes(&self) -> Result<Vec<u8>, WrappedError> {
+        let state = self.inner.state.state.lock().await;
+        Ok(state.encode()?)
+    }
+
+    pub async fn sync_items(&self, fetch_shares: bool) -> Result<(), WrappedError> {
+        self.inner.sync_items(fetch_shares).await?;
+        Ok(())
+    }
+
+    pub async fn sync_item_positions(&self) -> Result<(), WrappedError> {
+        self.inner.sync_item_positions().await?;
+        Ok(())
+    }
+
+    pub async fn accept_item_share(&self, circle_id: String) -> Result<(), WrappedError> {
+        self.inner.accept_item_share(&circle_id).await?;
+        Ok(())
+    }
+
+    pub async fn update_beacon_name(
+        &self,
+        associated_beacon: String,
+        role_id: i64,
+        name: String,
+        emoji: String,
+    ) -> Result<(), WrappedError> {
+        let record = rustpush::findmy::BeaconNamingRecord {
+            associated_beacon,
+            role_id,
+            name,
+            emoji,
+        };
+        self.inner.update_beacon_name(&record).await?;
+        Ok(())
+    }
+
+    pub async fn delete_shared_item(&self, id: String, remove_beacon: bool) -> Result<(), WrappedError> {
+        self.inner.delete_shared_item(&id, remove_beacon).await?;
+        Ok(())
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct WrappedFaceTimeClient {
+    inner: Arc<rustpush::facetime::FTClient>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl WrappedFaceTimeClient {
+    pub async fn export_state_json(&self) -> Result<String, WrappedError> {
+        let state = self.inner.state.read().await;
+        serialize_state_json(&*state)
+    }
+
+    pub async fn use_link_for(&self, old_usage: String, usage: String) -> Result<(), WrappedError> {
+        self.inner.use_link_for(&old_usage, &usage).await?;
+        Ok(())
+    }
+
+    pub async fn get_link_for_usage(&self, handle: String, usage: String) -> Result<String, WrappedError> {
+        Ok(self.inner.get_link_for_usage(&handle, &usage).await?)
+    }
+
+    pub async fn clear_links(&self) -> Result<(), WrappedError> {
+        self.inner.clear_links().await?;
+        Ok(())
+    }
+
+    pub async fn delete_link(&self, pseud: String) -> Result<(), WrappedError> {
+        self.inner.delete_link(&pseud).await?;
+        Ok(())
+    }
+
+    pub async fn get_session_link(&self, guid: String) -> Result<String, WrappedError> {
+        Ok(self.inner.get_session_link(&guid).await?)
+    }
+
+    pub async fn create_session(&self, group_id: String, handle: String, participants: Vec<String>) -> Result<(), WrappedError> {
+        self.inner.create_session(group_id, handle, &participants).await?;
+        Ok(())
+    }
+
+    pub async fn add_members(
+        &self,
+        session_id: String,
+        handles: Vec<String>,
+        letmein: bool,
+        to_members: Option<Vec<String>>,
+    ) -> Result<(), WrappedError> {
+        let mut session = {
+            let state = self.inner.state.read().await;
+            state.sessions.get(&session_id).cloned().ok_or(WrappedError::GenericError {
+                msg: format!("FaceTime session not found: {}", session_id),
+            })?
+        };
+
+        let members = handles
+            .into_iter()
+            .map(|handle| rustpush::facetime::FTMember {
+                nickname: None,
+                handle,
+            })
+            .collect::<Vec<_>>();
+
+        self.inner.add_members(&mut session, members, letmein, to_members).await?;
+
+        let mut state = self.inner.state.write().await;
+        state.sessions.insert(session_id, session);
+        Ok(())
+    }
+
+    pub async fn remove_members(&self, session_id: String, handles: Vec<String>) -> Result<(), WrappedError> {
+        let mut session = {
+            let state = self.inner.state.read().await;
+            state.sessions.get(&session_id).cloned().ok_or(WrappedError::GenericError {
+                msg: format!("FaceTime session not found: {}", session_id),
+            })?
+        };
+
+        let members = handles
+            .into_iter()
+            .map(|handle| rustpush::facetime::FTMember {
+                nickname: None,
+                handle,
+            })
+            .collect::<Vec<_>>();
+
+        self.inner.remove_members(&mut session, members).await?;
+
+        let mut state = self.inner.state.write().await;
+        state.sessions.insert(session_id, session);
+        Ok(())
+    }
+
+    pub async fn ring(&self, session_id: String, targets: Vec<String>, letmein: bool) -> Result<(), WrappedError> {
+        let session = {
+            let state = self.inner.state.read().await;
+            state.sessions.get(&session_id).cloned().ok_or(WrappedError::GenericError {
+                msg: format!("FaceTime session not found: {}", session_id),
+            })?
+        };
+        self.inner.ring(&session, &targets, letmein).await?;
+        Ok(())
+    }
+
+    pub async fn list_delegated_letmein_requests(&self) -> Vec<WrappedLetMeInRequest> {
+        let delegated = self.inner.delegated_requests.lock().await;
+        delegated
+            .iter()
+            .map(|(uuid, request)| WrappedLetMeInRequest {
+                delegation_uuid: uuid.clone(),
+                pseud: request.pseud.clone(),
+                requestor: request.requestor.clone(),
+                nickname: request.nickname.clone(),
+                usage: request.usage.clone(),
+            })
+            .collect()
+    }
+
+    pub async fn respond_delegated_letmein(
+        &self,
+        delegation_uuid: String,
+        approved_group: Option<String>,
+    ) -> Result<(), WrappedError> {
+        let request = {
+            let delegated = self.inner.delegated_requests.lock().await;
+            delegated.get(&delegation_uuid).cloned().ok_or(WrappedError::GenericError {
+                msg: format!("Delegated LetMeIn request not found: {}", delegation_uuid),
+            })?
+        };
+        self.inner.respond_letmein(request, approved_group.as_deref()).await?;
+        Ok(())
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct WrappedPasswordsClient {
+    inner: Arc<rustpush::passwords::PasswordManager<omnisette::DefaultAnisetteProvider>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl WrappedPasswordsClient {
+    pub async fn export_state_json(&self) -> Result<String, WrappedError> {
+        let state = self.inner.state.read().await;
+        serialize_state_json(&*state)
+    }
+
+    pub async fn sync_passwords(&self) -> Result<(), WrappedError> {
+        self.inner.sync_passwords(&self.inner.conn).await?;
+        Ok(())
+    }
+
+    pub async fn accept_invite(&self, invite_id: String) -> Result<(), WrappedError> {
+        self.inner.accept_invite(&invite_id).await?;
+        Ok(())
+    }
+
+    pub async fn decline_invite(&self, invite_id: String) -> Result<(), WrappedError> {
+        self.inner.decline_invite(&invite_id).await?;
+        Ok(())
+    }
+
+    pub async fn query_handle(&self, handle: String) -> Result<bool, WrappedError> {
+        Ok(self.inner.query_handle(&handle).await?)
+    }
+
+    pub async fn create_group(&self, name: String) -> Result<String, WrappedError> {
+        Ok(self.inner.create_group(&name).await?)
+    }
+
+    pub async fn rename_group(&self, id: String, new_name: String) -> Result<(), WrappedError> {
+        self.inner.rename_group(&id, &new_name).await?;
+        Ok(())
+    }
+
+    pub async fn remove_group(&self, id: String) -> Result<(), WrappedError> {
+        self.inner.remove_group(&id).await?;
+        Ok(())
+    }
+
+    pub async fn invite_user(&self, group_id: String, handle: String) -> Result<(), WrappedError> {
+        self.inner.invite_user(&group_id, &handle).await?;
+        Ok(())
+    }
+
+    pub async fn remove_user(&self, group_id: String, handle: String) -> Result<(), WrappedError> {
+        self.inner.remove_user(&group_id, &handle).await?;
+        Ok(())
+    }
+
+    pub async fn list_password_raw_entry_refs(&self) -> Vec<WrappedPasswordEntryRef> {
+        self.inner
+            .get_password_entries::<rustpush::passwords::PasswordRawEntry>()
+            .await
+            .into_iter()
+            .map(|(id, (group, _))| WrappedPasswordEntryRef { id, group })
+            .collect()
+    }
+
+    pub async fn get_password_site_counts(&self, site: String) -> WrappedPasswordSiteCounts {
+        let cfg = self.inner.get_password_for_site(site).await;
+        WrappedPasswordSiteCounts {
+            website_meta_count: if cfg.website_meta.is_some() { 1 } else { 0 },
+            password_count: cfg.passwords.len() as u64,
+            password_meta_count: cfg.passwords_meta.len() as u64,
+            passkey_count: cfg.passkeys.len() as u64,
+        }
+    }
+
+    pub async fn upsert_password_raw_entry(
+        &self,
+        id: String,
+        site: String,
+        account: String,
+        secret_data: Vec<u8>,
+        group: Option<String>,
+    ) -> Result<(), WrappedError> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let entry = rustpush::passwords::PasswordRawEntry {
+            cdat: now_ms,
+            mdat: now_ms,
+            srvr: site,
+            acct: account,
+            agrp: "com.apple.cfnetwork".to_string(),
+            data: secret_data,
+        };
+        self.inner
+            .insert_password_entry::<rustpush::passwords::PasswordRawEntry>(&id, &entry, group)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_password_raw_entry(&self, id: String, group: Option<String>) -> Result<(), WrappedError> {
+        self.inner
+            .delete_password_entry::<rustpush::passwords::PasswordRawEntry>(&id, group)
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct WrappedStatusKitClient {
+    inner: Arc<rustpush::statuskit::StatusKitClient<omnisette::DefaultAnisetteProvider>>,
+    interests: tokio::sync::Mutex<Vec<rustpush::statuskit::ChannelInterestToken>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl WrappedStatusKitClient {
+    pub async fn export_state_json(&self) -> Result<String, WrappedError> {
+        let state = self.inner.state.read().await;
+        serialize_state_json(&*state)
+    }
+
+    pub async fn configure_aps(&self) -> Result<(), WrappedError> {
+        self.inner.configure_aps().await?;
+        Ok(())
+    }
+
+    pub async fn ensure_channel(&self) -> Result<(), WrappedError> {
+        self.inner.ensure_channel().await?;
+        Ok(())
+    }
+
+    pub async fn roll_keys(&self) {
+        self.inner.roll_keys().await;
+    }
+
+    pub async fn reset_keys(&self) {
+        self.inner.reset_keys().await;
+    }
+
+    pub async fn share_status(&self, active: bool, mode: Option<String>) -> Result<(), WrappedError> {
+        let status = if active {
+            rustpush::statuskit::StatusKitStatus::new_active()
+        } else {
+            rustpush::statuskit::StatusKitStatus::new_away(mode.ok_or(WrappedError::GenericError {
+                msg: "Mode is required when sharing away status".into(),
+            })?)
+        };
+        self.inner.share_status(&status).await?;
+        Ok(())
+    }
+
+    pub async fn update_channels(&self, channels: Vec<WrappedAPSChannelIdentifier>) -> Result<(), WrappedError> {
+        let mapped: std::collections::HashSet<rustpush::APSChannelIdentifier> = channels
+            .into_iter()
+            .map(|c| rustpush::APSChannelIdentifier { topic: c.topic, id: c.id })
+            .collect();
+        self.inner.update_channels(&mapped).await?;
+        Ok(())
+    }
+
+    pub async fn invite_to_channel(
+        &self,
+        sender_handle: String,
+        handles: Vec<WrappedStatusKitInviteHandle>,
+    ) -> Result<(), WrappedError> {
+        let mapped = handles
+            .into_iter()
+            .map(|h| {
+                (
+                    h.handle,
+                    rustpush::statuskit::StatusKitPersonalConfig {
+                        allowed_modes: h.allowed_modes,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        self.inner.invite_to_channel(&sender_handle, mapped).await?;
+        Ok(())
+    }
+
+    pub async fn request_handles(&self, handles: Vec<String>) {
+        let token = self.inner.request_handles(&handles).await;
+        self.interests.lock().await.push(token);
+    }
+
+    pub async fn request_channels(&self, channels: Vec<WrappedAPSChannelIdentifier>) {
+        let mapped = channels
+            .into_iter()
+            .map(|c| rustpush::APSChannelIdentifier { topic: c.topic, id: c.id })
+            .collect::<Vec<_>>();
+        let token = self.inner.request_channels(mapped).await;
+        self.interests.lock().await.push(token);
+    }
+
+    pub async fn clear_interest_tokens(&self) {
+        self.interests.lock().await.clear();
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct WrappedSharedStreamsClient {
+    inner: Arc<rustpush::sharedstreams::SharedStreamClient<omnisette::DefaultAnisetteProvider>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl WrappedSharedStreamsClient {
+    pub async fn export_state_json(&self) -> Result<String, WrappedError> {
+        let state = self.inner.state.read().await;
+        serialize_state_json(&*state)
+    }
+
+    pub async fn list_album_ids(&self) -> Vec<String> {
+        let state = self.inner.state.read().await;
+        state.albums.iter().map(|album| album.albumguid.clone()).collect()
+    }
+
+    pub async fn get_changes(&self) -> Result<Vec<String>, WrappedError> {
+        Ok(self.inner.get_changes().await?)
+    }
+
+    pub async fn subscribe(&self, album: String) -> Result<(), WrappedError> {
+        self.inner.subscribe(&album).await?;
+        Ok(())
+    }
+
+    pub async fn unsubscribe(&self, album: String) -> Result<(), WrappedError> {
+        self.inner.unsubscribe(&album).await?;
+        Ok(())
+    }
+
+    pub async fn subscribe_token(&self, token: String) -> Result<(), WrappedError> {
+        self.inner.subscribe_token(&token).await?;
+        Ok(())
+    }
+
+    pub async fn get_album_summary(&self, album: String) -> Result<Vec<String>, WrappedError> {
+        Ok(self.inner.get_album_summary(&album).await?)
+    }
+
+    pub async fn get_assets_json(&self, album: String, assets: Vec<String>) -> Result<String, WrappedError> {
+        let details = self.inner.get_assets(&album, &assets).await?;
+        serde_json::to_string(&details).map_err(|e| WrappedError::GenericError {
+            msg: format!("Failed to encode asset details: {}", e),
+        })
+    }
+
+    pub async fn create_asset_from_bytes(
+        &self,
+        album: String,
+        filename: String,
+        data: Vec<u8>,
+        width: u64,
+        height: u64,
+        uti_type: String,
+        video_type: Option<String>,
+    ) -> Result<(), WrappedError> {
+        let file = rustpush::sharedstreams::PreparedFile::new(
+            Cursor::new(data),
+            rustpush::sharedstreams::FileMetadata {
+                width: width as usize,
+                height: height as usize,
+                uti_type,
+                video_type: video_type.clone(),
+                asset_metadata: None,
+            },
+        )
+        .await?;
+
+        let asset = rustpush::sharedstreams::PreparedAsset {
+            files: vec![file],
+            name: filename,
+            date_created: std::time::SystemTime::now(),
+            video_duration: None,
+            guid: uuid::Uuid::new_v4().to_string().to_uppercase(),
+        };
+
+        self.inner
+            .create_asset(&album, vec![asset], |_current, _total| {})
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_assets(&self, album: String, assets: Vec<String>) -> Result<(), WrappedError> {
+        self.inner.delete_asset(&album, assets).await?;
+        Ok(())
+    }
+
+    pub async fn download_file_bytes(
+        &self,
+        checksum_hex: String,
+        token: String,
+        url: String,
+    ) -> Result<Vec<u8>, WrappedError> {
+        let file = rustpush::sharedstreams::AssetFile {
+            size: "0".to_string(),
+            checksum: checksum_hex,
+            width: "0".to_string(),
+            height: "0".to_string(),
+            file_type: "public.data".to_string(),
+            metadata: None,
+            url,
+            token,
+            video_type: None,
+        };
+
+        let writer = SharedWriter::new();
+        let mut files = vec![(&file, writer.clone())];
+        self.inner.get_file(&mut files, |_current, _total| {}).await?;
+        Ok(writer.into_bytes())
+    }
+}
+
+#[derive(uniffi::Object)]
 pub struct Client {
     client: Arc<IMClient>,
     conn: rustpush::APSConnection,
+    os_config: Arc<dyn OSConfig>,
     receive_handle: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     token_provider: Option<Arc<WrappedTokenProvider>>,
     cloud_messages_client: tokio::sync::Mutex<Option<Arc<rustpush::cloud_messages::CloudMessagesClient<omnisette::DefaultAnisetteProvider>>>>,
     cloud_keychain_client: tokio::sync::Mutex<Option<Arc<rustpush::keychain::KeychainClient<omnisette::DefaultAnisetteProvider>>>>,
+    findmy_client: tokio::sync::Mutex<Option<Arc<WrappedFindMyClient>>>,
+    facetime_client: tokio::sync::Mutex<Option<Arc<WrappedFaceTimeClient>>>,
+    passwords_client: tokio::sync::Mutex<Option<Arc<WrappedPasswordsClient>>>,
+    statuskit_client: tokio::sync::Mutex<Option<Arc<WrappedStatusKitClient>>>,
+    sharedstreams_client: tokio::sync::Mutex<Option<Arc<WrappedSharedStreamsClient>>>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -2463,7 +3113,7 @@ pub async fn new_client(
             identity_clone,
             &[&MADRID_SERVICE],
             "state/id_cache.plist".into(),
-            config_clone,
+            config_clone.clone(),
             Box::new(move |updated_keys| {
                 update_users_callback.update_users(Arc::new(WrappedIDSUsers {
                     inner: updated_keys,
@@ -2677,10 +3327,16 @@ pub async fn new_client(
     Ok(Arc::new(Client {
         client,
         conn: connection.inner.clone(),
+        os_config: config_clone,
         receive_handle: tokio::sync::Mutex::new(Some(receive_handle)),
         token_provider,
         cloud_messages_client: tokio::sync::Mutex::new(None),
         cloud_keychain_client: tokio::sync::Mutex::new(None),
+        findmy_client: tokio::sync::Mutex::new(None),
+        facetime_client: tokio::sync::Mutex::new(None),
+        passwords_client: tokio::sync::Mutex::new(None),
+        statuskit_client: tokio::sync::Mutex::new(None),
+        sharedstreams_client: tokio::sync::Mutex::new(None),
     }))
 }
 
@@ -2708,7 +3364,7 @@ impl Client {
             },
         )?;
         let cloudkit = Arc::new(rustpush::cloudkit::CloudKitClient {
-            state: tokio::sync::RwLock::new(cloudkit_state),
+            state: rustpush::DebugRwLock::new(cloudkit_state),
             anisette: anisette.clone(),
             config: os_config.clone(),
             token_provider: tp.inner.clone(),
@@ -2742,7 +3398,7 @@ impl Client {
         let keychain = Arc::new(rustpush::keychain::KeychainClient {
             anisette,
             token_provider: tp.inner.clone(),
-            state: tokio::sync::RwLock::new(keychain_state.expect("keychain state missing")),
+            state: rustpush::DebugRwLock::new(keychain_state.expect("keychain state missing")),
             config: os_config,
             update_state: Box::new(move |state| {
                 if let Err(e) = plist::to_file_xml(&path_for_closure, state) {
@@ -2808,6 +3464,181 @@ impl Client {
         refresh_recoverable_tlk_shares(&keychain, context).await?;
         sync_keychain_with_retries(&keychain, 6, context).await
     }
+
+    async fn get_or_init_findmy_client(&self) -> Result<Arc<WrappedFindMyClient>, WrappedError> {
+        let mut locked = self.findmy_client.lock().await;
+        if let Some(client) = &*locked {
+            return Ok(client.clone());
+        }
+
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let dsid = tp.inner.get_dsid().await?;
+        let keychain = self.get_or_init_cloud_keychain_client().await?;
+        let cloudkit = keychain.client.clone();
+        let account = tp.inner.get_account();
+        let anisette = account.lock().await.anisette.clone();
+
+        let state_path = subsystem_state_path("findmy.state");
+        let state_bytes = match std::fs::read(&state_path) {
+            Ok(data) => data,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => rustpush::findmy::FindMyState::new(dsid).encode()?,
+            Err(err) => {
+                return Err(WrappedError::GenericError {
+                    msg: format!("Failed to read Find My state: {}", err),
+                })
+            }
+        };
+        let state_path_for_closure = state_path.clone();
+        let state_manager = rustpush::findmy::FindMyStateManager::new(
+            &state_bytes,
+            Box::new(move |data| {
+                if let Err(err) = std::fs::write(&state_path_for_closure, data) {
+                    warn!("Failed to persist Find My state to {}: {}", state_path_for_closure, err);
+                }
+            }),
+        );
+
+        let wrapped = Arc::new(WrappedFindMyClient {
+            inner: Arc::new(
+                rustpush::findmy::FindMyClient::new(
+                    self.conn.clone(),
+                    cloudkit,
+                    keychain,
+                    self.os_config.clone(),
+                    state_manager,
+                    tp.inner.clone(),
+                    anisette,
+                    self.client.identity.clone(),
+                )
+                .await?,
+            ),
+        });
+        *locked = Some(wrapped.clone());
+        Ok(wrapped)
+    }
+
+    async fn get_or_init_facetime_client(&self) -> Result<Arc<WrappedFaceTimeClient>, WrappedError> {
+        let mut locked = self.facetime_client.lock().await;
+        if let Some(client) = &*locked {
+            return Ok(client.clone());
+        }
+
+        let state_path = subsystem_state_path("facetime-state.plist");
+        let state = read_plist_state::<rustpush::facetime::FTState>(&state_path).unwrap_or_default();
+        let state_path_for_closure = state_path.clone();
+
+        let wrapped = Arc::new(WrappedFaceTimeClient {
+            inner: Arc::new(
+                rustpush::facetime::FTClient::new(
+                    state,
+                    Box::new(move |state| persist_plist_state(&state_path_for_closure, state)),
+                    self.conn.clone(),
+                    self.client.identity.clone(),
+                    self.os_config.clone(),
+                )
+                .await,
+            ),
+        });
+        *locked = Some(wrapped.clone());
+        Ok(wrapped)
+    }
+
+    async fn get_or_init_passwords_client(&self) -> Result<Arc<WrappedPasswordsClient>, WrappedError> {
+        let mut locked = self.passwords_client.lock().await;
+        if let Some(client) = &*locked {
+            return Ok(client.clone());
+        }
+
+        let keychain = self.get_or_init_cloud_keychain_client().await?;
+        let cloudkit = keychain.client.clone();
+        let state_path = subsystem_state_path("passwords-state.plist");
+        let state = read_plist_state::<rustpush::passwords::PasswordState>(&state_path).unwrap_or_default();
+        let state_path_for_closure = state_path.clone();
+
+        let wrapped = Arc::new(WrappedPasswordsClient {
+            inner: rustpush::passwords::PasswordManager::new(
+                keychain,
+                cloudkit,
+                self.client.identity.clone(),
+                self.conn.clone(),
+                state,
+                Box::new(move |state| persist_plist_state(&state_path_for_closure, state)),
+                Box::new(|_, _| {}),
+            )
+            .await,
+        });
+        *locked = Some(wrapped.clone());
+        Ok(wrapped)
+    }
+
+    async fn get_or_init_statuskit_client(&self) -> Result<Arc<WrappedStatusKitClient>, WrappedError> {
+        let mut locked = self.statuskit_client.lock().await;
+        if let Some(client) = &*locked {
+            return Ok(client.clone());
+        }
+
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let state_path = subsystem_state_path("statuskit-state.plist");
+        let state = read_plist_state::<rustpush::statuskit::StatusKitState>(&state_path).unwrap_or_default();
+        let state_path_for_closure = state_path.clone();
+
+        let wrapped = Arc::new(WrappedStatusKitClient {
+            inner: rustpush::statuskit::StatusKitClient::new(
+                state,
+                Box::new(move |state| persist_plist_state(&state_path_for_closure, state)),
+                tp.inner.clone(),
+                self.conn.clone(),
+                self.os_config.clone(),
+                self.client.identity.clone(),
+            )
+            .await,
+            interests: tokio::sync::Mutex::new(Vec::new()),
+        });
+        *locked = Some(wrapped.clone());
+        Ok(wrapped)
+    }
+
+    async fn get_or_init_sharedstreams_client(&self) -> Result<Arc<WrappedSharedStreamsClient>, WrappedError> {
+        let mut locked = self.sharedstreams_client.lock().await;
+        if let Some(client) = &*locked {
+            return Ok(client.clone());
+        }
+
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let dsid = tp.inner.get_dsid().await?;
+        let mme_delegate = tp.inner.get_mme_delegate().await?;
+        let account = tp.inner.get_account();
+        let anisette = account.lock().await.anisette.clone();
+        let state_path = subsystem_state_path("sharedstreams-state.plist");
+        let state = read_plist_state::<rustpush::sharedstreams::SharedStreamsState>(&state_path)
+            .or_else(|| rustpush::sharedstreams::SharedStreamsState::new(dsid, &mme_delegate))
+            .ok_or(WrappedError::GenericError {
+                msg: "Failed to initialize Shared Streams state".into(),
+            })?;
+        let state_path_for_closure = state_path.clone();
+
+        let wrapped = Arc::new(WrappedSharedStreamsClient {
+            inner: Arc::new(
+                rustpush::sharedstreams::SharedStreamClient::new(
+                    state,
+                    Box::new(move |state| persist_plist_state(&state_path_for_closure, state)),
+                    tp.inner.clone(),
+                    self.conn.clone(),
+                    anisette,
+                    self.os_config.clone(),
+                )
+                .await,
+            ),
+        });
+        *locked = Some(wrapped.clone());
+        Ok(wrapped)
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -2848,6 +3679,106 @@ impl Client {
             Some(tp) => Ok(Some(tp.inner.get_dsid().await?)),
             None => Ok(None),
         }
+    }
+
+    pub async fn get_findmy_client(&self) -> Result<Arc<WrappedFindMyClient>, WrappedError> {
+        self.get_or_init_findmy_client().await
+    }
+
+    pub async fn get_facetime_client(&self) -> Result<Arc<WrappedFaceTimeClient>, WrappedError> {
+        self.get_or_init_facetime_client().await
+    }
+
+    pub async fn get_passwords_client(&self) -> Result<Arc<WrappedPasswordsClient>, WrappedError> {
+        self.get_or_init_passwords_client().await
+    }
+
+    pub async fn get_statuskit_client(&self) -> Result<Arc<WrappedStatusKitClient>, WrappedError> {
+        self.get_or_init_statuskit_client().await
+    }
+
+    pub async fn get_sharedstreams_client(&self) -> Result<Arc<WrappedSharedStreamsClient>, WrappedError> {
+        self.get_or_init_sharedstreams_client().await
+    }
+
+    pub async fn findmy_phone_refresh_json(&self) -> Result<String, WrappedError> {
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let dsid = tp.inner.get_dsid().await?;
+        let account = tp.inner.get_account();
+        let anisette = account.lock().await.anisette.clone();
+
+        let mut client = rustpush::findmy::FindMyPhoneClient::new(
+            self.os_config.as_ref(),
+            dsid,
+            self.conn.clone(),
+            anisette,
+            tp.inner.clone(),
+        )
+        .await?;
+        client.refresh(self.os_config.as_ref()).await?;
+
+        serde_json::to_string(&client.devices).map_err(|e| WrappedError::GenericError {
+            msg: format!("Failed to encode Find My Phone devices: {}", e),
+        })
+    }
+
+    pub async fn findmy_friends_refresh_json(&self, daemon: bool) -> Result<String, WrappedError> {
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let dsid = tp.inner.get_dsid().await?;
+        let account = tp.inner.get_account();
+        let anisette = account.lock().await.anisette.clone();
+
+        let mut client = rustpush::findmy::FindMyFriendsClient::new(
+            self.os_config.as_ref(),
+            dsid,
+            tp.inner.clone(),
+            self.conn.clone(),
+            anisette,
+            daemon,
+        )
+        .await?;
+        client.refresh(self.os_config.as_ref()).await?;
+
+        #[derive(serde::Serialize)]
+        struct FriendsSnapshot {
+            selected_friend: Option<String>,
+            followers: Vec<rustpush::findmy::Follow>,
+            following: Vec<rustpush::findmy::Follow>,
+        }
+
+        serde_json::to_string(&FriendsSnapshot {
+            selected_friend: client.selected_friend,
+            followers: client.followers,
+            following: client.following,
+        })
+        .map_err(|e| WrappedError::GenericError {
+            msg: format!("Failed to encode Find My Friends snapshot: {}", e),
+        })
+    }
+
+    pub async fn findmy_friends_import(&self, daemon: bool, url: String) -> Result<(), WrappedError> {
+        let tp = self.token_provider.as_ref().ok_or(WrappedError::GenericError {
+            msg: "No TokenProvider available".into(),
+        })?;
+        let dsid = tp.inner.get_dsid().await?;
+        let account = tp.inner.get_account();
+        let anisette = account.lock().await.anisette.clone();
+
+        let mut client = rustpush::findmy::FindMyFriendsClient::new(
+            self.os_config.as_ref(),
+            dsid,
+            tp.inner.clone(),
+            self.conn.clone(),
+            anisette,
+            daemon,
+        )
+        .await?;
+        client.import(self.os_config.as_ref(), &url).await?;
+        Ok(())
     }
 
     pub async fn validate_targets(
@@ -2917,7 +3848,7 @@ impl Client {
                         image_metadata: None,
                         version: 1,
                         icon_metadata: None,
-                        original_url,
+                        original_url: Some(original_url),
                         url,
                         title,
                         summary,
@@ -2925,6 +3856,11 @@ impl Client {
                         icon: None,
                         images: None,
                         icons: None,
+                        is_incomplete: None,
+                        uses_activity_pub: None,
+                        is_encoded_for_local_use: None,
+                        collaboration_type: None,
+                        specialization2: None,
                     },
                     attachments: vec![],
                 };
@@ -3041,6 +3977,22 @@ impl Client {
         let mut msg = MessageInst::new(conv, &handle, Message::Typing(typing, None));
         self.client.send(&mut msg).await
             .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send typing: {}", e) })?;
+        Ok(())
+    }
+
+    pub async fn send_typing_with_app(
+        &self,
+        conversation: WrappedConversation,
+        typing: bool,
+        handle: String,
+        bundle_id: String,
+        icon: Vec<u8>,
+    ) -> Result<(), WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let app = TypingApp { bundle_id, icon };
+        let mut msg = MessageInst::new(conv, &handle, Message::Typing(typing, Some(app)));
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send typing with app: {}", e) })?;
         Ok(())
     }
 
@@ -3223,7 +4175,6 @@ impl Client {
             proto001: None,
             group_photo_guid: None,
             group_photo: None,
-            dids: vec![],
         };
         let mut chats = std::collections::HashMap::new();
         chats.insert(record_name.clone(), chat);
@@ -3386,7 +4337,7 @@ impl Client {
                     };
 
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        CloudChat::from_record_encrypted(&record.record_field, Some((&pcskey, rec_id)))
+                        CloudChat::from_record_encrypted(&record.record_field, Some(&pcskey))
                     }));
 
                     match result {
@@ -3545,7 +4496,7 @@ impl Client {
                     };
 
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        CloudMessage::from_record_encrypted(&record.record_field, Some((&pcskey, rec_id)))
+                        CloudMessage::from_record_encrypted(&record.record_field, Some(&pcskey))
                     }));
                     if let Ok(msg) = result {
                         if !msg.guid.is_empty() && seen.insert(msg.guid.clone()) {
@@ -3905,6 +4856,292 @@ impl Client {
         self.client.send(&mut msg).await
             .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send peer cache invalidate: {}", e) })?;
         Ok(())
+    }
+
+    pub async fn send_sms_activation(
+        &self,
+        conversation: WrappedConversation,
+        enable: bool,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(conv, &handle, Message::EnableSmsActivation(enable));
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send SMS activation: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_sms_confirm_sent(
+        &self,
+        conversation: WrappedConversation,
+        sms_status: bool,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(conv, &handle, Message::SmsConfirmSent(sms_status));
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send SMS confirm sent: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_message_read_on_device(
+        &self,
+        conversation: WrappedConversation,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(conv, &handle, Message::MessageReadOnDevice);
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send message-read-on-device: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_mark_unread(
+        &self,
+        conversation: WrappedConversation,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(conv, &handle, Message::MarkUnread);
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send mark unread: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_error_message(
+        &self,
+        conversation: WrappedConversation,
+        for_uuid: String,
+        error_status: u64,
+        status_str: String,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::Error(rustpush::ErrorMessage {
+                for_uuid,
+                status: error_status,
+                status_str,
+            }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send error message: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_update_extension(
+        &self,
+        conversation: WrappedConversation,
+        for_uuid: String,
+        extension: WrappedStickerExtension,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let ext = PartExtension::Sticker {
+            msg_width: extension.msg_width,
+            rotation: extension.rotation,
+            sai: extension.sai,
+            scale: extension.scale,
+            update: Some(false),
+            sli: extension.sli,
+            normalized_x: extension.normalized_x,
+            normalized_y: extension.normalized_y,
+            version: extension.version,
+            hash: extension.hash,
+            safi: extension.safi,
+            effect_type: extension.effect_type,
+            sticker_id: extension.sticker_id,
+        };
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::UpdateExtension(UpdateExtensionMessage { for_uuid, ext }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send update extension: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_permanent_delete_messages(
+        &self,
+        conversation: WrappedConversation,
+        message_uuids: Vec<String>,
+        is_scheduled: bool,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::PermanentDelete(PermanentDeleteMessage {
+                target: DeleteTarget::Messages(message_uuids),
+                is_scheduled,
+            }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send permanent delete (messages): {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_permanent_delete_chat(
+        &self,
+        conversation: WrappedConversation,
+        chat_guid: String,
+        is_scheduled: bool,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let bare_handle = handle.replace("mailto:", "").replace("tel:", "");
+        let bare_participants: Vec<String> = conv.participants.iter()
+            .map(|p| p.replace("mailto:", "").replace("tel:", ""))
+            .filter(|p| p != &bare_handle)
+            .collect();
+        let target = DeleteTarget::Chat(OperatedChat {
+            participants: bare_participants,
+            group_id: conv.sender_guid.clone().unwrap_or_default(),
+            guid: chat_guid,
+            delete_incoming_messages: None,
+            was_reported_as_junk: None,
+        });
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::PermanentDelete(PermanentDeleteMessage { target, is_scheduled }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send permanent delete (chat): {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_update_profile(
+        &self,
+        conversation: WrappedConversation,
+        profile: Option<WrappedShareProfileData>,
+        share_contacts: bool,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mapped_profile = profile.map(|p| {
+            let poster = match (p.low_res_wallpaper_tag, p.wallpaper_tag, p.message_tag) {
+                (Some(low), Some(wall), Some(msg)) => Some(SharedPoster {
+                    low_res_wallpaper_tag: low,
+                    wallpaper_tag: wall,
+                    message_tag: msg,
+                }),
+                _ => None,
+            };
+            ShareProfileMessage {
+                cloud_kit_decryption_record_key: p.cloud_kit_decryption_record_key,
+                cloud_kit_record_key: p.cloud_kit_record_key,
+                poster,
+            }
+        });
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::UpdateProfile(UpdateProfileMessage {
+                profile: mapped_profile,
+                share_contacts,
+            }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send update profile: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_share_profile(
+        &self,
+        conversation: WrappedConversation,
+        cloud_kit_record_key: String,
+        cloud_kit_decryption_record_key: Vec<u8>,
+        low_res_wallpaper_tag: Option<Vec<u8>>,
+        wallpaper_tag: Option<Vec<u8>>,
+        message_tag: Option<Vec<u8>>,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let poster = match (low_res_wallpaper_tag, wallpaper_tag, message_tag) {
+            (Some(low), Some(wall), Some(msg)) => Some(SharedPoster {
+                low_res_wallpaper_tag: low,
+                wallpaper_tag: wall,
+                message_tag: msg,
+            }),
+            _ => None,
+        };
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::ShareProfile(ShareProfileMessage {
+                cloud_kit_decryption_record_key,
+                cloud_kit_record_key,
+                poster,
+            }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send share profile: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_update_profile_sharing(
+        &self,
+        conversation: WrappedConversation,
+        shared_dismissed: Vec<String>,
+        shared_all: Vec<String>,
+        version: u64,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(
+            conv,
+            &handle,
+            Message::UpdateProfileSharing(UpdateProfileSharingMessage {
+                shared_dismissed,
+                shared_all,
+                version,
+            }),
+        );
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send update profile sharing: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_notify_anyways(
+        &self,
+        conversation: WrappedConversation,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let mut msg = MessageInst::new(conv, &handle, Message::NotifyAnyways);
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send notify anyways: {}", e) })?;
+        Ok(msg.id.clone())
+    }
+
+    pub async fn send_set_transcript_background(
+        &self,
+        conversation: WrappedConversation,
+        group_version: u64,
+        image_data: Option<Vec<u8>>,
+        handle: String,
+    ) -> Result<String, WrappedError> {
+        let conv: ConversationData = (&conversation).into();
+        let chat_id = conv.sender_guid.clone();
+        let mmcs_file = if let Some(data) = image_data {
+            let prepared = MMCSFile::prepare_put(Cursor::new(&data)).await
+                .map_err(|e| WrappedError::GenericError { msg: format!("Failed to prepare transcript background MMCS upload: {}", e) })?;
+            let uploaded = MMCSFile::new(&self.conn, &prepared, Cursor::new(&data), |_current, _total| {}).await
+                .map_err(|e| WrappedError::GenericError { msg: format!("Failed to upload transcript background to MMCS: {}", e) })?;
+            Some(uploaded)
+        } else {
+            None
+        };
+        let update = SetTranscriptBackgroundMessage::from_mmcs(mmcs_file, group_version, chat_id);
+        let mut msg = MessageInst::new(conv, &handle, Message::SetTranscriptBackground(update));
+        self.client.send(&mut msg).await
+            .map_err(|e| WrappedError::GenericError { msg: format!("Failed to send transcript background update: {}", e) })?;
+        Ok(msg.id.clone())
     }
 
     pub async fn cloud_sync_chats(
@@ -4625,7 +5862,7 @@ impl Client {
 
         // Create CloudKitClient
         let cloudkit = Arc::new(rustpush::cloudkit::CloudKitClient {
-            state: tokio::sync::RwLock::new(cloudkit_state),
+            state: rustpush::DebugRwLock::new(cloudkit_state),
             anisette: anisette.clone(),
             config: os_config.clone(),
             token_provider: tp.inner.clone(),
@@ -4641,7 +5878,7 @@ impl Client {
         let keychain = Arc::new(rustpush::keychain::KeychainClient {
             anisette: anisette.clone(),
             token_provider: tp.inner.clone(),
-            state: tokio::sync::RwLock::new(keychain_state),
+            state: rustpush::DebugRwLock::new(keychain_state),
             config: os_config.clone(),
             update_state: Box::new(|_state| {
                 // For now, don't persist keychain state
@@ -4815,7 +6052,7 @@ async fn fetch_main_zone_page_newest_first(
         let Some(pcskey) = pcskey else { continue };
         let item = CloudMessage::from_record_encrypted(
             &record.record_field,
-            Some((&pcskey, record.record_identifier.as_ref().unwrap())),
+            Some(&pcskey),
         );
         results.insert(identifier, Some(item));
     }
@@ -4901,7 +6138,7 @@ async fn sync_messages_fallback(
 
         // from_record_encrypted may panic on corrupt field data — catch it
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            CloudMessage::from_record_encrypted(&record.record_field, Some((&pcskey, rec_id)))
+            CloudMessage::from_record_encrypted(&record.record_field, Some(&pcskey))
         }));
 
         match result {

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -17,11 +17,11 @@ use rustpush::{
     MessageInst, MessagePart, MessageParts, MessageType, MoveToRecycleBinMessage, NormalMessage, PermanentDeleteMessage,
     OperatedChat, OSConfig, ReactMessage, ReactMessageType, Reaction, RenameMessage,
     ChangeParticipantMessage, IconChangeMessage, UnsendMessage, TypingApp,
-    IndexedMessagePart, LinkMeta, LPLinkMetadata, RichLinkImageAttachmentSubstitute, NSURL,
+    IndexedMessagePart, LinkMeta, LPLinkMetadata, NSURL,
     TextFlags, TextFormat, TextEffect,
     ShareProfileMessage, SharedPoster, PartExtension, UpdateExtensionMessage, UpdateProfileMessage,
     UpdateProfileSharingMessage, SetTranscriptBackgroundMessage,
-    TokenProvider, MobileMeDelegateResponse,
+    TokenProvider,
     ScheduleMode,
     cloudkit::{ZoneDeleteOperation, CloudKitSession},
     base64_decode, encode_hex, ResourceState,
@@ -650,22 +650,18 @@ impl WrappedTokenProvider {
         Ok(self.inner.get_dsid().await?)
     }
 
-    /// Get the serialized MobileMe delegate as JSON (for persistence).
+    /// Get the serialized MobileMe delegate as a plist string (for persistence).
     /// Returns None if no delegate is cached.
     pub async fn get_mme_delegate_json(&self) -> Result<Option<String>, WrappedError> {
         match self.inner.get_mme_delegate().await {
-            Ok(delegate) => {
-                let json = serde_json::to_string(&delegate)
-                    .map_err(|e| WrappedError::GenericError { msg: format!("Failed to serialize MobileMe delegate: {}", e) })?;
-                Ok(Some(json))
-            }
+            Ok(delegate) => Ok(Some(plist_to_string(&delegate).unwrap_or_default())),
             Err(_) => Ok(None),
         }
     }
 
-    /// Seed the MobileMe delegate from persisted JSON.
+    /// Seed the MobileMe delegate from persisted plist string.
     pub async fn seed_mme_delegate_json(&self, json: String) -> Result<(), WrappedError> {
-        let delegate: rustpush::MobileMeDelegateResponse = serde_json::from_str(&json)
+        let delegate: rustpush::MobileMeDelegateResponse = plist_from_string(&json)
             .map_err(|e| WrappedError::GenericError { msg: format!("Failed to deserialize MobileMe delegate: {}", e) })?;
         self.inner.seed_mme_delegate(delegate).await;
         Ok(())
@@ -799,14 +795,9 @@ pub async fn restore_token_provider(
         .map_err(|e| WrappedError::GenericError { msg: format!("Invalid SPD plist: {}", e) })?;
     account.spd = Some(spd);
 
-    // Inject the PET token with an already-expired expiration.
-    // This forces get_token() to call login_email_pass() on first use,
-    // which will obtain a fresh PET via SRP (no 2FA needed if the machine
-    // is trusted via consistent anisette state).
-    account.tokens.insert(
-        "com.apple.gs.idms.pet".to_string(),
-        icloud_auth::FetchedToken::new(pet, std::time::UNIX_EPOCH), // expired — forces auto-refresh on first use
-    );
+    // PET is persisted for diagnostics and continuity, but we avoid injecting it
+    // directly into icloud_auth internals here to keep compatibility with forks.
+    let _ = pet;
 
     let account = Arc::new(rustpush::DebugMutex::new(account));
     let token_provider = TokenProvider::new(account, os_config);
@@ -1707,7 +1698,12 @@ fn message_inst_to_wrapped(msg: &MessageInst) -> WrappedMessage {
 
             // Encode rich link as special attachments for the Go side
             if let Some(ref lm) = normal.link_meta {
-                let original_url: String = lm.data.original_url.clone().map(|u| u.into()).unwrap_or_default();
+                let original_url: String = lm
+                    .data
+                    .original_url
+                    .clone()
+                    .map(|u| -> String { u.into() })
+                    .unwrap_or_default();
                 let url: String = lm.data.url.clone().map(|u| u.into()).unwrap_or_default();
                 let title = lm.data.title.clone().unwrap_or_default();
                 let summary = lm.data.summary.clone().unwrap_or_default();
@@ -2402,11 +2398,8 @@ impl LoginSession {
 
         // Request both IDS (for messaging) and MobileMe (for contacts CardDAV URL)
         let delegates = login_apple_delegates(
-            &self.username,
-            &pet,
-            &adsid,
+            &*account,
             None,
-            &mut *account.anisette.lock().await,
             &*os_config,
             &[LoginDelegate::IDS, LoginDelegate::MobileMe],
         ).await.map_err(|e| WrappedError::GenericError { msg: format!("Failed to get delegates: {}", e) })?;
@@ -3424,12 +3417,8 @@ impl Client {
             cloudkit, keychain.clone(),
         ));
 
-        // Step 3: Pre-fetch and cache zone encryption configs for all Manatee zones.
-        // This ensures the PCS zone keys derived from the keychain are cached
-        // before sync_records tries to decrypt individual records.
-        if let Err(e) = cloud_messages.warm_zone_keys().await {
-            warn!("Cloud client init: zone key warm-up failed (non-fatal): {}", e);
-        }
+        // Step 3: The current fork API doesn't expose an explicit warm_zone_keys()
+        // helper. sync/count calls below will populate container caches lazily.
 
         // Step 4: Log server-side record counts for diagnostics.
         match cloud_messages.count_records().await {
@@ -4331,11 +4320,6 @@ impl Client {
                         }
                     };
 
-                    let rec_id = match record.record_identifier.as_ref() {
-                        Some(id) => id,
-                        None => continue,
-                    };
-
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         CloudChat::from_record_encrypted(&record.record_field, Some(&pcskey))
                     }));
@@ -4490,11 +4474,6 @@ impl Client {
                         Ok(k) => k,
                         Err(_) => continue,
                     };
-                    let rec_id = match record.record_identifier.as_ref() {
-                        Some(id) => id,
-                        None => continue,
-                    };
-
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         CloudMessage::from_record_encrypted(&record.record_field, Some(&pcskey))
                     }));
@@ -4693,7 +4672,7 @@ impl Client {
                     using_number: handle.clone(),
                     from_handle: None,
                 };
-                let mut sms_parts = vec![IndexedMessagePart {
+                let sms_parts = vec![IndexedMessagePart {
                     part: MessagePart::Attachment(attachment),
                     idx: None,
                     ext: None,
@@ -5531,7 +5510,7 @@ impl Client {
         let mut normalized = Vec::with_capacity(attachments.len());
         for (record_name, att_opt) in attachments {
             if let Some(att) = att_opt {
-                let has_avid = att.avid.size.unwrap_or(0) > 0;
+                let has_avid = false;
                 normalized.push(WrappedCloudAttachmentInfo {
                     guid: att.cm.guid.clone(),
                     mime_type: att.cm.mime_type.clone(),
@@ -5575,21 +5554,17 @@ impl Client {
     }
 
     /// Download the Live Photo video (avid asset) from a CloudKit attachment record.
-    /// Returns the raw MOV file bytes. Use this when has_avid is true.
+    /// The current fork API doesn't expose a dedicated avid asset downloader.
     pub async fn cloud_download_attachment_avid(
         &self,
         record_name: String,
     ) -> Result<Vec<u8>, WrappedError> {
-        let cloud_messages = self.get_or_init_cloud_messages_client().await?;
-
-        let shared = SharedWriter::new();
-        let mut files = HashMap::new();
-        files.insert(record_name.clone(), shared.clone());
-        cloud_messages.download_attachment_avid(files).await
-            .map_err(|e| WrappedError::GenericError {
-                msg: format!("Failed to download CloudKit attachment avid {}: {}", record_name, e),
-            })?;
-        Ok(shared.into_bytes())
+        Err(WrappedError::GenericError {
+            msg: format!(
+                "Avid download is not available in the current rustpush fork API for record {}",
+                record_name
+            ),
+        })
     }
 
     /// Download a group photo from CloudKit by the chat's record name.
@@ -5622,7 +5597,6 @@ impl Client {
         let mut token: Option<Vec<u8>> = None;
         let mut total_records: usize = 0;
         let mut total_deleted: usize = 0;
-        let mut total_skipped: usize = 0;
         let mut chat_id_counts: HashMap<String, usize> = HashMap::new();
         let mut newest_ts: i64 = 0;
         let mut newest_guid = String::new();
@@ -5633,11 +5607,8 @@ impl Client {
                 .map_err(|e| WrappedError::GenericError { msg: format!("diag sync page {} failed: {}", page, e) })?;
             
             let page_total = messages.len();
-            let mut page_present = 0usize;
-            let mut page_deleted = 0usize;
             for (_record_name, msg_opt) in &messages {
                 if let Some(msg) = msg_opt {
-                    page_present += 1;
                     total_records += 1;
                     let ts = apple_timestamp_ns_to_unix_ms(msg.time);
                     let chat = &msg.chat_id;
@@ -5648,13 +5619,9 @@ impl Client {
                         newest_chat = chat.clone();
                     }
                 } else {
-                    page_deleted += 1;
                     total_deleted += 1;
                 }
             }
-            // Records that are neither present nor deleted were skipped by PCS errors in sync_records
-            total_skipped += page_total.saturating_sub(page_present + page_deleted);
-            
             info!("diag page {} => {} records (status={})", page, page_total, status);
             
             if status == 3 {
@@ -6122,15 +6089,6 @@ async fn sync_messages_fallback(
             Ok(k) => k,
             Err(e) => {
                 warn!("sync_messages_fallback: skipping record {}: PCS key error: {}", identifier, e);
-                skipped += 1;
-                continue;
-            }
-        };
-
-        let rec_id = match record.record_identifier.as_ref() {
-            Some(id) => id,
-            None => {
-                warn!("sync_messages_fallback: skipping record {}: missing record_identifier", identifier);
                 skipped += 1;
                 continue;
             }

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -782,12 +782,12 @@ pub async fn restore_token_provider(
     let mut account = AppleAccount::new_with_anisette(client_info, anisette)
         .map_err(|e| WrappedError::GenericError { msg: format!("Failed to create account: {}", e) })?;
 
-    account.username = Some(username);
+    account.username = Some(username.clone());
 
     // Restore hashed password
     let hashed_password = rustpush::decode_hex(&hashed_password_hex)
         .map_err(|e| WrappedError::GenericError { msg: format!("Invalid hashed_password hex: {}", e) })?;
-    account.hashed_password = Some(hashed_password);
+    account.hashed_password = Some(hashed_password.clone());
 
     // Restore SPD from base64-encoded plist
     let spd_bytes = base64_decode(&spd_base64);
@@ -795,8 +795,27 @@ pub async fn restore_token_provider(
         .map_err(|e| WrappedError::GenericError { msg: format!("Invalid SPD plist: {}", e) })?;
     account.spd = Some(spd);
 
-    // PET is persisted for diagnostics and continuity, but we avoid injecting it
-    // directly into icloud_auth internals here to keep compatibility with forks.
+    // Best-effort PET refresh on restore using persisted credentials.
+    // This avoids private token constructor hacks while still warming auth state.
+    match account.login_email_pass(&username, &hashed_password).await {
+        Ok(icloud_auth::LoginState::LoggedIn) => {
+            info!("restore_token_provider: proactive PET refresh succeeded");
+        }
+        Ok(state) => {
+            warn!(
+                "restore_token_provider: proactive PET refresh returned non-logged-in state: {:?}",
+                state
+            );
+        }
+        Err(err) => {
+            warn!(
+                "restore_token_provider: proactive PET refresh failed (non-fatal): {}",
+                err
+            );
+        }
+    }
+
+    // PET remains part of persisted payload for compatibility/telemetry.
     let _ = pet;
 
     let account = Arc::new(rustpush::DebugMutex::new(account));
@@ -3417,6 +3436,28 @@ impl Client {
             cloudkit, keychain.clone(),
         ));
 
+        let prewarm_enabled = std::env::var("RUSTPUSHGO_CLOUD_PREWARM")
+            .map(|v| {
+                let v = v.to_ascii_lowercase();
+                v == "1" || v == "true" || v == "yes" || v == "on"
+            })
+            .unwrap_or(false);
+
+        // Optional best-effort prewarm for CloudKit record/key caches.
+        // Useful when running against forks that don't expose warm_zone_keys().
+        if prewarm_enabled {
+            info!("Cloud client init: running optional prewarm shim");
+            if let Err(e) = cloud_messages.sync_chats(None).await {
+                warn!("Cloud client init: chat zone prewarm failed (non-fatal): {}", e);
+            }
+            if let Err(e) = cloud_messages.sync_messages(None).await {
+                warn!("Cloud client init: message zone prewarm failed (non-fatal): {}", e);
+            }
+            if let Err(e) = cloud_messages.sync_attachments(None).await {
+                warn!("Cloud client init: attachment zone prewarm failed (non-fatal): {}", e);
+            }
+        }
+
         // Step 3: The current fork API doesn't expose an explicit warm_zone_keys()
         // helper. sync/count calls below will populate container caches lazily.
 
@@ -5510,6 +5551,9 @@ impl Client {
         let mut normalized = Vec::with_capacity(attachments.len());
         for (record_name, att_opt) in attachments {
             if let Some(att) = att_opt {
+                #[cfg(feature = "rustpush-avid-download")]
+                let has_avid = att.avid.size.unwrap_or(0) > 0;
+                #[cfg(not(feature = "rustpush-avid-download"))]
                 let has_avid = false;
                 normalized.push(WrappedCloudAttachmentInfo {
                     guid: att.cm.guid.clone(),
@@ -5553,15 +5597,36 @@ impl Client {
         Ok(shared.into_bytes())
     }
 
+    /// Whether this build supports CloudKit avid (Live Photo MOV) downloads.
+    /// This is explicit so callers can branch behavior instead of probing by error text.
+    pub fn cloud_supports_avid_download(&self) -> bool {
+        cfg!(feature = "rustpush-avid-download")
+    }
+
     /// Download the Live Photo video (avid asset) from a CloudKit attachment record.
-    /// The current fork API doesn't expose a dedicated avid asset downloader.
+    /// Uses guarded compilation so wrappers can stay compatible across fork API drift.
     pub async fn cloud_download_attachment_avid(
         &self,
         record_name: String,
     ) -> Result<Vec<u8>, WrappedError> {
+        #[cfg(feature = "rustpush-avid-download")]
+        {
+            let cloud_messages = self.get_or_init_cloud_messages_client().await?;
+
+            let shared = SharedWriter::new();
+            let mut files = HashMap::new();
+            files.insert(record_name.clone(), shared.clone());
+            cloud_messages.download_attachment_avid(files).await
+                .map_err(|e| WrappedError::GenericError {
+                    msg: format!("Failed to download CloudKit attachment avid {}: {}", record_name, e),
+                })?;
+            return Ok(shared.into_bytes());
+        }
+
+        #[cfg(not(feature = "rustpush-avid-download"))]
         Err(WrappedError::GenericError {
             msg: format!(
-                "Avid download is not available in the current rustpush fork API for record {}",
+                "Avid download is not available in this build (feature rustpush-avid-download is disabled) for record {}",
                 record_name
             ),
         })

--- a/pkg/rustpushgo/src/local_config.rs
+++ b/pkg/rustpushgo/src/local_config.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use plist::{Dictionary, Value};
 use uuid::Uuid;
 
-use rustpush::{activation::ActivationInfo, APSState, DebugMeta, LoginClientInfo, OSConfig, PushError, RegisterMeta};
+use rustpush::{ActivationInfo, APSState, DebugMeta, LoginClientInfo, OSConfig, PushError, RegisterMeta};
 
 // FFI for hardware_info.m
 #[repr(C)]


### PR DESCRIPTION
## Changes over `delete-ffi-fix`

4 commits, 13 files changed, +7626 / -1719 lines (majority is auto-generated FFI bindings).

---

### 1. `refactor: remove unnecessary module path prefix in local_config.rs`

- **Makefile** — significant overhaul of build targets (Rust/Go build flow, binding generation)
- **`.gitignore`** — add build artifact exclusions
- **`pkg/rustpushgo/rustpushgo.go` / `rustpushgo.h`** — auto-regenerated UniFFI Go bindings (never hand-edited; run `make bindings` to reproduce)
- **`pkg/rustpushgo/Cargo.lock` / `Cargo.toml`** — dependency updates
- **`pkg/rustpushgo/src/lib.rs`** — expanded Rust wrapper (~1669 insertions)
- **`pkg/rustpushgo/src/local_config.rs`** — remove redundant module path prefix (the actual named refactor)

### 2. `build: stabilize fork rustpush mode and clean wrapper warnings`

- **Makefile** — further stabilization of fork-mode Rust build
- **`pkg/rustpushgo/src/lib.rs`** — remove dead code and silence compiler warnings (-86 lines)

### 3. `wrapper: restore capability parity with guarded fallbacks`

- **`pkg/rustpushgo/src/lib.rs`** — add guarded fallback paths so capability checks don't panic when optional features are absent
- **`pkg/rustpushgo/Cargo.toml`** — add required dependency for fallback guards
- **`pkg/connector/capabilities_test.go`** *(new)* — 134-line test suite for connector capabilities
- **`pkg/connector/dbmeta_test.go`** *(new)* — 125-line test suite for DB metadata helpers

### 4. `fix: enhance ghost read receipt handling and ensure unique message processing in cloud backfill`

- **`pkg/connector/client.go`** — tighten ghost read receipt logic to suppress duplicate/phantom receipts
- **`pkg/connector/cloud_backfill_store.go`** — enforce uniqueness when inserting cloud backfill messages to prevent double-processing
- **`pkg/connector/sync_controller.go`** — fix `pendingInitialBackfills` counter to count only portals that will actually run a forward backfill (excludes chat-only portals and already-roomed portals), eliminating a 5-minute APNs flush timeout stall