### PR TITLE
fix(connector): stabilize SMS and RCS portal handling

### DIFF
--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -276,6 +276,12 @@ func portalIDToChatGUIDs(portalID string) []string {
 	if localID == "" {
 		return nil
 	}
+	// Strip legacy (sms...) suffix from pre-fix portal IDs so chat.db GUID
+	// candidates match: "tel:+12155167207(smsft)" → localID "+12155167207(smsft)"
+	// → stripped "+12155167207", producing "any;-;+12155167207" which matches chat.db.
+	if idx := strings.Index(localID, "(sms"); idx > 0 {
+		localID = localID[:idx]
+	}
 	return []string{
 		"any;-;" + localID,
 		"iMessage;-;" + localID,
@@ -288,18 +294,25 @@ func identifierToPortalID(id imessage.Identifier) networkid.PortalID {
 	if id.IsGroup {
 		return networkid.PortalID(id.String())
 	}
-	if strings.HasPrefix(id.LocalID, "+") {
-		return networkid.PortalID("tel:" + id.LocalID)
+	localID := id.LocalID
+	// Strip Apple SMS service suffixes: "+12155167207(smsft)" → "+12155167207",
+	// "787473(smsft)" → "787473". These are native Apple formats that appear in
+	// chat.db for SMS Forwarding service types.
+	if idx := strings.Index(localID, "(sms"); idx > 0 {
+		localID = localID[:idx]
 	}
-	if strings.Contains(id.LocalID, "@") {
-		return networkid.PortalID("mailto:" + id.LocalID)
+	if strings.HasPrefix(localID, "+") {
+		return networkid.PortalID("tel:" + localID)
+	}
+	if strings.Contains(localID, "@") {
+		return networkid.PortalID("mailto:" + localID)
 	}
 	// Short codes and numeric-only identifiers (e.g., "242733") are SMS-based.
 	// Rustpush creates these with "tel:" prefix, so we must match.
-	if isNumeric(id.LocalID) {
-		return networkid.PortalID("tel:" + id.LocalID)
+	if isNumeric(localID) {
+		return networkid.PortalID("tel:" + localID)
 	}
-	return networkid.PortalID(id.LocalID)
+	return networkid.PortalID(localID)
 }
 
 // ============================================================================
@@ -316,7 +329,7 @@ func chatDBMakeEventSender(msg *imessage.Message, c *IMClient) bridgev2.EventSen
 	}
 	return bridgev2.EventSender{
 		IsFromMe: false,
-		Sender:   makeUserID(addIdentifierPrefix(msg.Sender.LocalID)),
+		Sender:   makeUserID(addIdentifierPrefix(stripSmsSuffix(msg.Sender.LocalID))),
 	}
 }
 

--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -279,9 +279,7 @@ func portalIDToChatGUIDs(portalID string) []string {
 	// Strip legacy (sms...) suffix from pre-fix portal IDs so chat.db GUID
 	// candidates match: "tel:+12155167207(smsft)" → localID "+12155167207(smsft)"
 	// → stripped "+12155167207", producing "any;-;+12155167207" which matches chat.db.
-	if idx := strings.Index(localID, "(sms"); idx > 0 {
-		localID = localID[:idx]
-	}
+	localID = stripSmsSuffix(localID)
 	return []string{
 		"any;-;" + localID,
 		"iMessage;-;" + localID,
@@ -298,9 +296,7 @@ func identifierToPortalID(id imessage.Identifier) networkid.PortalID {
 	// Strip Apple SMS service suffixes: "+12155167207(smsft)" → "+12155167207",
 	// "787473(smsft)" → "787473". These are native Apple formats that appear in
 	// chat.db for SMS Forwarding service types.
-	if idx := strings.Index(localID, "(sms"); idx > 0 {
-		localID = localID[:idx]
-	}
+	localID = stripSmsSuffix(localID)
 	if strings.HasPrefix(localID, "+") {
 		return networkid.PortalID("tel:" + localID)
 	}

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -596,6 +596,9 @@ func (c *IMClient) loadSenderGuidsFromDB(log zerolog.Logger) {
 				c.imGroupGuidsMu.Unlock()
 				loadedGuids++
 			}
+			if meta.IsSms {
+				c.updatePortalSMS(string(portal.ID), true)
+			}
 			// NOTE: Do NOT pre-populate imGroupNames from portal metadata.
 			// The metadata GroupName can be stale (polluted by previous CloudKit
 			// sync cycles). Loading it on startup would cause resolveGroupName
@@ -873,7 +876,15 @@ func (c *IMClient) OnMessage(msg rustpushgo.WrappedMessage) {
 	// Send delivery receipt if requested
 	if msg.SendDelivered && msg.Sender != nil && !msg.IsDelivered && !msg.IsReadReceipt {
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Error().Interface("panic", r).Msg("Panic in SendDeliveryReceipt")
+				}
+			}()
 			conv := c.makeConversation(msg.Participants, msg.GroupName)
+			if c.client == nil {
+				return
+			}
 			if err := c.client.SendDeliveryReceipt(conv, c.handle); err != nil {
 				log.Warn().Err(err).Msg("Failed to send delivery receipt")
 			}
@@ -1128,10 +1139,29 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 		}
 	}
 
-	// Track SMS portals so outbound replies use the correct service type
-	if msg.IsSms {
-		c.markPortalSMS(string(portalKey.ID))
-	}
+	// Track SMS portals so outbound replies use the correct service type.
+	// Unconditional so SMS→iMessage transitions are reflected immediately.
+	c.updatePortalSMS(string(portalKey.ID), msg.IsSms)
+	// Persist IsSms to PortalMetadata for existing portals (handles SMS↔iMessage
+	// transitions). For brand-new portals, GetExistingPortalByKey returns nil and
+	// the goroutine exits without persisting — that case is covered by the
+	// GetChatInfo ExtraUpdates hook, which reads isPortalSMS() (already set above)
+	// when the framework calls GetChatInfo to create the new portal.
+	go func(pk networkid.PortalKey, isSms bool) {
+		bgCtx := context.Background()
+		portal, portalErr := c.Main.Bridge.GetExistingPortalByKey(bgCtx, pk)
+		if portalErr == nil && portal != nil {
+			meta := &PortalMetadata{}
+			if existing, ok := portal.Metadata.(*PortalMetadata); ok {
+				*meta = *existing
+			}
+			if meta.IsSms != isSms {
+				meta.IsSms = isSms
+				portal.Metadata = meta
+				_ = portal.Save(bgCtx)
+			}
+		}
+	}(portalKey, msg.IsSms)
 
 	// Only create new portals after CloudKit sync is done.
 	cloudSyncDone := c.isCloudSyncDone()
@@ -2587,7 +2617,7 @@ func (c *IMClient) refreshRecoveredChatMetadata(log zerolog.Logger, portalID str
 			var token *string
 			const maxChatScanPages = 30
 			for page := 0; page < maxChatScanPages; page++ {
-				chatsPage, pageErr := c.client.CloudSyncChats(token)
+				chatsPage, pageErr := safeCloudSyncChats(c.client, token)
 				if pageErr != nil {
 					log.Warn().Err(pageErr).Int("page", page).
 						Msg("CloudSyncChats page failed during main-zone name scan")
@@ -3680,6 +3710,9 @@ func (c *IMClient) HandleMatrixTyping(ctx context.Context, msg *bridgev2.MatrixT
 		return nil
 	}
 	conv := c.portalToConversation(msg.Portal)
+	if conv.IsSms {
+		return nil
+	}
 	return c.client.SendTyping(conv, msg.IsTyping, c.handle)
 }
 
@@ -3688,6 +3721,9 @@ func (c *IMClient) HandleMatrixReadReceipt(ctx context.Context, receipt *bridgev
 		return nil
 	}
 	conv := c.portalToConversation(receipt.Portal)
+	if conv.IsSms {
+		return nil
+	}
 	var forUuid *string
 	if receipt.ExactMessage != nil {
 		uuid := string(receipt.ExactMessage.ID)
@@ -3697,7 +3733,22 @@ func (c *IMClient) HandleMatrixReadReceipt(ctx context.Context, receipt *bridgev
 		}
 		forUuid = &uuid
 	}
-	return c.client.SendReadReceipt(conv, c.handle, forUuid)
+	err := c.client.SendReadReceipt(conv, c.handle, forUuid)
+	if err != nil {
+		errStr := err.Error()
+		// Suppress non-actionable failures: IDS lookup errors (6001) for
+		// urn:biz: business chat portals and edge cases between restart and SMS
+		// state restoration; NoValidTargets for contacts with no reachable handle.
+		// All other errors propagate normally so real network/auth failures surface.
+		if strings.Contains(errStr, "6001") || strings.Contains(errStr, "NoValidTargets") {
+			zerolog.Ctx(ctx).Warn().Err(err).
+				Str("portal_id", string(receipt.Portal.ID)).
+				Msg("Read receipt failed (non-actionable, suppressed)")
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *IMClient) HandleMatrixEdit(ctx context.Context, msg *bridgev2.MatrixEdit) error {
@@ -3706,6 +3757,9 @@ func (c *IMClient) HandleMatrixEdit(ctx context.Context, msg *bridgev2.MatrixEdi
 	}
 
 	conv := c.portalToConversation(msg.Portal)
+	if conv.IsSms {
+		return fmt.Errorf("edits are not supported for SMS conversations")
+	}
 	targetGUID := string(msg.EditTarget.ID)
 
 	_, err := c.client.SendEdit(conv, targetGUID, 0, msg.Content.Body, c.handle)
@@ -3721,10 +3775,13 @@ func (c *IMClient) HandleMatrixMessageRemove(ctx context.Context, msg *bridgev2.
 		return bridgev2.ErrNotLoggedIn
 	}
 
+	conv := c.portalToConversation(msg.Portal)
+	if conv.IsSms {
+		return fmt.Errorf("message retraction is not supported for SMS conversations")
+	}
+
 	// Track outbound unsend so we can suppress the APNs echo.
 	c.trackOutboundUnsend(string(msg.TargetMessage.ID))
-
-	conv := c.portalToConversation(msg.Portal)
 	_, err := c.client.SendUnsend(conv, string(msg.TargetMessage.ID), 0, c.handle)
 
 	// Soft-delete the message in local DB so it doesn't re-bridge on backfill,
@@ -3928,7 +3985,13 @@ func (c *IMClient) portalToChatGUID(portalID string) string {
 	if strings.HasPrefix(portalID, "gid:") {
 		return service + ";+;" + strings.TrimPrefix(portalID, "gid:")
 	}
-	return service + ";-;" + strings.TrimPrefix(strings.TrimPrefix(portalID, "tel:"), "mailto:")
+	cleanID := strings.TrimPrefix(strings.TrimPrefix(portalID, "tel:"), "mailto:")
+	// Strip legacy (sms...) suffix from pre-fix portal IDs so the chat GUID
+	// passed to Rust is well-formed (e.g., "SMS;-;+12155167207" not "SMS;-;+12155167207(smsft)").
+	if idx := strings.Index(cleanID, "(sms"); idx > 0 {
+		cleanID = cleanID[:idx]
+	}
+	return service + ";-;" + cleanID
 }
 
 // deleteFromApple sends MoveToRecycleBin via APNs and deletes known CloudKit
@@ -4241,6 +4304,7 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 			c.imGroupNamesMu.RLock()
 			protocolName := c.imGroupNames[portalID]
 			c.imGroupNamesMu.RUnlock()
+			isSms := c.isPortalSMS(portalID)
 			chatInfo.ExtraUpdates = func(ctx context.Context, p *bridgev2.Portal) bool {
 				meta, ok := p.Metadata.(*PortalMetadata)
 				if !ok {
@@ -4253,6 +4317,10 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 				}
 				if protocolName != "" && meta.GroupName != protocolName {
 					meta.GroupName = protocolName
+					changed = true
+				}
+				if meta.IsSms != isSms {
+					meta.IsSms = isSms
 					changed = true
 				}
 				if changed {
@@ -4319,6 +4387,22 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 		// private_chat_portal_meta, the framework derives it from the ghost's
 		// display name, which auto-updates when contacts are edited.
 		chatInfo.Members = members
+
+		// Persist IsSms so CloudKit-created portals (no suffix, no live APNs
+		// message yet) survive restarts. Mirrors the group ExtraUpdates pattern.
+		isSms := c.isPortalSMS(portalID)
+		chatInfo.ExtraUpdates = func(ctx context.Context, p *bridgev2.Portal) bool {
+			meta, ok := p.Metadata.(*PortalMetadata)
+			if !ok {
+				meta = &PortalMetadata{}
+			}
+			if meta.IsSms != isSms {
+				meta.IsSms = isSms
+				p.Metadata = meta
+				return true
+			}
+			return false
+		}
 	}
 
 	return chatInfo, nil
@@ -6100,6 +6184,12 @@ func normalizeIdentifierForPortalID(identifier string) string {
 	if id == "" {
 		return ""
 	}
+	// Strip Apple SMS service suffixes: "+12155167207(smsft)" → "+12155167207",
+	// "787473(smsft)" → "787473". Must happen before any other processing so
+	// the suffix never reaches isNumeric / normalizePhone checks.
+	if idx := strings.Index(id, "(sms"); idx > 0 {
+		id = id[:idx]
+	}
 
 	if strings.HasPrefix(id, "mailto:") {
 		return "mailto:" + strings.ToLower(strings.TrimPrefix(id, "mailto:"))
@@ -7055,7 +7145,14 @@ func (c *IMClient) portalToConversation(portal *bridgev2.Portal) rustpushgo.Wrap
 
 	// For DMs, resolve the best sendable identifier. For merged contacts,
 	// the portal ID might be an inactive number that rustpush can't send to.
-	sendTo := c.resolveSendTarget(portalID)
+	// Strip any legacy (sms...) suffix before resolution — resolveSendTarget
+	// calls lookupContact → stripIdentifierPrefix, which would pass the suffix
+	// through to contact lookup and break alternate-handle resolution.
+	cleanPortalID := portalID
+	if idx := strings.Index(cleanPortalID, "(sms"); idx > 0 {
+		cleanPortalID = cleanPortalID[:idx]
+	}
+	sendTo := c.resolveSendTarget(cleanPortalID)
 
 	// For self-chats, only include one participant. Duplicating our own
 	// handle (e.g. [self, self]) causes rustpush to reject the message
@@ -7781,16 +7878,22 @@ func mimeToMsgType(mime string) event.MessageType {
 	}
 }
 
-func (c *IMClient) markPortalSMS(portalID string) {
+func (c *IMClient) updatePortalSMS(portalID string, isSms bool) {
 	c.smsPortalsLock.Lock()
 	defer c.smsPortalsLock.Unlock()
-	c.smsPortals[portalID] = true
+	c.smsPortals[portalID] = isSms
 }
 
 func (c *IMClient) isPortalSMS(portalID string) bool {
 	c.smsPortalsLock.RLock()
 	defer c.smsPortalsLock.RUnlock()
-	return c.smsPortals[portalID]
+	if c.smsPortals[portalID] {
+		return true
+	}
+	// Fallback for legacy portals that still have the raw suffix in their ID
+	// (pre-fix DB entries that survive without a full reset). Such portals can
+	// never transition to iMessage — their IDs are malformed by definition.
+	return strings.Contains(portalID, "(sms")
 }
 
 func (c *IMClient) trackUnsend(uuid string) {
@@ -7986,6 +8089,7 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 		chatGUID  string
 		portalKey networkid.PortalKey
 		info      *imessage.ChatInfo
+		isSms     bool
 	}
 	var entries []chatEntry
 	for _, chat := range chats {
@@ -7995,6 +8099,7 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 		}
 		parsed := imessage.ParseIdentifier(chat.ChatGUID)
 		var portalKey networkid.PortalKey
+		isSms := parsed.Service == "SMS"
 		if parsed.IsGroup {
 			members := make([]string, 0, len(info.Members)+1)
 			members = append(members, addIdentifierPrefix(c.handle))
@@ -8012,10 +8117,14 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 				Receiver: c.UserLogin.ID,
 			}
 		}
+		if isSms {
+			c.updatePortalSMS(string(portalKey.ID), true)
+		}
 		entries = append(entries, chatEntry{
 			chatGUID:  chat.ChatGUID,
 			portalKey: portalKey,
 			info:      info,
+			isSms:     isSms,
 		})
 	}
 
@@ -8084,12 +8193,24 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 		done := make(chan struct{})
 		chatInfo := c.chatDBInfoToBridgev2(entry.info)
 		chatGUID := entry.chatGUID
+		isSms := entry.isSms
 		c.UserLogin.QueueRemoteEvent(&simplevent.ChatResync{
 			EventMeta: simplevent.EventMeta{
 				Type:         bridgev2.RemoteEventChatResync,
 				PortalKey:    entry.portalKey,
 				CreatePortal: true,
 				PostHandleFunc: func(ctx context.Context, portal *bridgev2.Portal) {
+					if isSms {
+						meta := &PortalMetadata{}
+						if existing, ok := portal.Metadata.(*PortalMetadata); ok {
+							*meta = *existing
+						}
+						if !meta.IsSms {
+							meta.IsSms = true
+							portal.Metadata = meta
+							_ = portal.Save(ctx)
+						}
+					}
 					close(done)
 				},
 				LogContext: func(lc zerolog.Context) zerolog.Context {
@@ -8164,7 +8285,7 @@ func (c *IMClient) chatDBInfoToBridgev2(info *imessage.ChatInfo) *bridgev2.ChatI
 			Membership: event.MembershipJoin,
 		}
 		for _, memberID := range info.Members {
-			userID := makeUserID(addIdentifierPrefix(memberID))
+			userID := makeUserID(addIdentifierPrefix(stripSmsSuffix(memberID)))
 			members.MemberMap[userID] = bridgev2.ChatMember{
 				EventSender: bridgev2.EventSender{Sender: userID},
 				Membership:  event.MembershipJoin,
@@ -8173,7 +8294,7 @@ func (c *IMClient) chatDBInfoToBridgev2(info *imessage.ChatInfo) *bridgev2.ChatI
 		chatInfo.Members = members
 	} else {
 		chatInfo.Type = ptr.Ptr(database.RoomTypeDM)
-		portalID := addIdentifierPrefix(parsed.LocalID)
+		portalID := addIdentifierPrefix(stripSmsSuffix(parsed.LocalID))
 		otherUser := makeUserID(portalID)
 		isSelfChat := c.isMyHandle(portalID)
 

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1142,37 +1142,9 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	// Track SMS portals so outbound replies use the correct service type.
 	// Unconditional so SMS→iMessage transitions are reflected immediately.
 	c.updatePortalSMS(string(portalKey.ID), msg.IsSms)
-	// Persist IsSms to PortalMetadata for existing portals (handles SMS↔iMessage
-	// transitions). For brand-new portals, GetExistingPortalByKey returns nil and
-	// the goroutine exits without persisting — that case is covered by the
-	// GetChatInfo ExtraUpdates hook, which reads isPortalSMS() (already set above)
-	// when the framework calls GetChatInfo to create the new portal.
-	go func(pk networkid.PortalKey, isSms bool) {
-		bgCtx := context.Background()
-		portal, portalErr := c.Main.Bridge.GetExistingPortalByKey(bgCtx, pk)
-		if portalErr != nil {
-			c.UserLogin.Log.Warn().Err(portalErr).
-				Str("portal_id", string(pk.ID)).
-				Msg("Failed to look up portal for IsSms persistence")
-			return
-		}
-		if portal == nil {
-			return
-		}
-		meta := &PortalMetadata{}
-		if existing, ok := portal.Metadata.(*PortalMetadata); ok {
-			*meta = *existing
-		}
-		if meta.IsSms != isSms {
-			meta.IsSms = isSms
-			portal.Metadata = meta
-			if err := portal.Save(bgCtx); err != nil {
-				c.UserLogin.Log.Warn().Err(err).
-					Str("portal_id", string(pk.ID)).
-					Msg("Failed to persist IsSms metadata")
-			}
-		}
-	}(portalKey, msg.IsSms)
+	// IsSms persistence is handled by the GetChatInfo ExtraUpdates hook, which
+	// reads isPortalSMS() (already set above via updatePortalSMS). This avoids
+	// a race between a detached goroutine and the framework's own metadata updates.
 
 	// Only create new portals after CloudKit sync is done.
 	cloudSyncDone := c.isCloudSyncDone()

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -8104,7 +8104,7 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 			members := make([]string, 0, len(info.Members)+1)
 			members = append(members, addIdentifierPrefix(c.handle))
 			for _, m := range info.Members {
-				members = append(members, addIdentifierPrefix(m))
+				members = append(members, addIdentifierPrefix(stripSmsSuffix(m)))
 			}
 			sort.Strings(members)
 			portalKey = networkid.PortalKey{

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -6464,6 +6464,8 @@ func (c *IMClient) reIDPortalWithCacheUpdate(ctx context.Context, oldKey, newKey
 	c.groupPortalMu.Lock()
 	c.lastGroupForMemberMu.Lock()
 	c.gidAliasesMu.Lock()
+	c.smsPortalsLock.Lock()
+	defer c.smsPortalsLock.Unlock()
 	defer c.gidAliasesMu.Unlock()
 	defer c.lastGroupForMemberMu.Unlock()
 	defer c.groupPortalMu.Unlock()
@@ -6512,6 +6514,11 @@ func (c *IMClient) reIDPortalWithCacheUpdate(ctx context.Context, oldKey, newKey
 		if target == oldID {
 			c.gidAliases[alias] = newID
 		}
+	}
+	// Move SMS portal flag
+	if isSms, ok := c.smsPortals[oldID]; ok {
+		c.smsPortals[newID] = isSms
+		delete(c.smsPortals, oldID)
 	}
 
 	return result, portal, nil

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1141,10 +1141,7 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 
 	// Track SMS portals so outbound replies use the correct service type.
 	// Unconditional so SMS→iMessage transitions are reflected immediately.
-	c.updatePortalSMS(string(portalKey.ID), msg.IsSms)
-	// IsSms persistence is handled by the GetChatInfo ExtraUpdates hook, which
-	// reads isPortalSMS() (already set above via updatePortalSMS). This avoids
-	// a race between a detached goroutine and the framework's own metadata updates.
+	smsChanged := c.updatePortalSMS(string(portalKey.ID), msg.IsSms)
 
 	// Only create new portals after CloudKit sync is done.
 	cloudSyncDone := c.isCloudSyncDone()
@@ -1164,6 +1161,31 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	backgroundCtx := context.Background()
 	msgTS := int64(msg.TimestampMs)
 	existingPortal, _ := c.Main.Bridge.GetExistingPortalByKey(backgroundCtx, portalKey)
+
+	// Persist IsSms change to DB immediately so it survives a crash.
+	// Without this, the in-memory update above would be lost on restart
+	// because loadSenderGuidsFromDB only loads IsSms=true entries.
+	if smsChanged && existingPortal != nil {
+		meta, ok := existingPortal.Metadata.(*PortalMetadata)
+		if !ok {
+			meta = &PortalMetadata{}
+		}
+		if meta.IsSms != msg.IsSms {
+			meta.IsSms = msg.IsSms
+			existingPortal.Metadata = meta
+			if err := existingPortal.Save(backgroundCtx); err != nil {
+				log.Warn().Err(err).
+					Str("portal_id", portalID).
+					Bool("is_sms", msg.IsSms).
+					Msg("Failed to persist IsSms change to database")
+			} else {
+				log.Debug().
+					Str("portal_id", portalID).
+					Bool("is_sms", msg.IsSms).
+					Msg("Persisted IsSms change to database")
+			}
+		}
+	}
 	missingPortal := existingPortal == nil || existingPortal.MXID == ""
 
 	// Lazy-load soft-deleted portal info. Only queries the DB when we
@@ -7854,10 +7876,12 @@ func mimeToMsgType(mime string) event.MessageType {
 	}
 }
 
-func (c *IMClient) updatePortalSMS(portalID string, isSms bool) {
+func (c *IMClient) updatePortalSMS(portalID string, isSms bool) bool {
 	c.smsPortalsLock.Lock()
 	defer c.smsPortalsLock.Unlock()
+	prev, existed := c.smsPortals[portalID]
 	c.smsPortals[portalID] = isSms
+	return !existed || prev != isSms
 }
 
 func (c *IMClient) isPortalSMS(portalID string) bool {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1150,15 +1150,26 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	go func(pk networkid.PortalKey, isSms bool) {
 		bgCtx := context.Background()
 		portal, portalErr := c.Main.Bridge.GetExistingPortalByKey(bgCtx, pk)
-		if portalErr == nil && portal != nil {
-			meta := &PortalMetadata{}
-			if existing, ok := portal.Metadata.(*PortalMetadata); ok {
-				*meta = *existing
-			}
-			if meta.IsSms != isSms {
-				meta.IsSms = isSms
-				portal.Metadata = meta
-				_ = portal.Save(bgCtx)
+		if portalErr != nil {
+			c.UserLogin.Log.Warn().Err(portalErr).
+				Str("portal_id", string(pk.ID)).
+				Msg("Failed to look up portal for IsSms persistence")
+			return
+		}
+		if portal == nil {
+			return
+		}
+		meta := &PortalMetadata{}
+		if existing, ok := portal.Metadata.(*PortalMetadata); ok {
+			*meta = *existing
+		}
+		if meta.IsSms != isSms {
+			meta.IsSms = isSms
+			portal.Metadata = meta
+			if err := portal.Save(bgCtx); err != nil {
+				c.UserLogin.Log.Warn().Err(err).
+					Str("portal_id", string(pk.ID)).
+					Msg("Failed to persist IsSms metadata")
 			}
 		}
 	}(portalKey, msg.IsSms)
@@ -3988,9 +3999,7 @@ func (c *IMClient) portalToChatGUID(portalID string) string {
 	cleanID := strings.TrimPrefix(strings.TrimPrefix(portalID, "tel:"), "mailto:")
 	// Strip legacy (sms...) suffix from pre-fix portal IDs so the chat GUID
 	// passed to Rust is well-formed (e.g., "SMS;-;+12155167207" not "SMS;-;+12155167207(smsft)").
-	if idx := strings.Index(cleanID, "(sms"); idx > 0 {
-		cleanID = cleanID[:idx]
-	}
+	cleanID = stripSmsSuffix(cleanID)
 	return service + ";-;" + cleanID
 }
 
@@ -6187,9 +6196,7 @@ func normalizeIdentifierForPortalID(identifier string) string {
 	// Strip Apple SMS service suffixes: "+12155167207(smsft)" → "+12155167207",
 	// "787473(smsft)" → "787473". Must happen before any other processing so
 	// the suffix never reaches isNumeric / normalizePhone checks.
-	if idx := strings.Index(id, "(sms"); idx > 0 {
-		id = id[:idx]
-	}
+	id = stripSmsSuffix(id)
 
 	if strings.HasPrefix(id, "mailto:") {
 		return "mailto:" + strings.ToLower(strings.TrimPrefix(id, "mailto:"))
@@ -7148,10 +7155,7 @@ func (c *IMClient) portalToConversation(portal *bridgev2.Portal) rustpushgo.Wrap
 	// Strip any legacy (sms...) suffix before resolution — resolveSendTarget
 	// calls lookupContact → stripIdentifierPrefix, which would pass the suffix
 	// through to contact lookup and break alternate-handle resolution.
-	cleanPortalID := portalID
-	if idx := strings.Index(cleanPortalID, "(sms"); idx > 0 {
-		cleanPortalID = cleanPortalID[:idx]
-	}
+	cleanPortalID := stripSmsSuffix(portalID)
 	sendTo := c.resolveSendTarget(cleanPortalID)
 
 	// For self-chats, only include one participant. Duplicating our own
@@ -7893,7 +7897,7 @@ func (c *IMClient) isPortalSMS(portalID string) bool {
 	// Fallback for legacy portals that still have the raw suffix in their ID
 	// (pre-fix DB entries that survive without a full reset). Such portals can
 	// never transition to iMessage — their IDs are malformed by definition.
-	return strings.Contains(portalID, "(sms")
+	return portalID != stripSmsSuffix(portalID)
 }
 
 func (c *IMClient) trackUnsend(uuid string) {
@@ -8208,7 +8212,11 @@ func (c *IMClient) runChatDBInitialSync(log zerolog.Logger) {
 						if !meta.IsSms {
 							meta.IsSms = true
 							portal.Metadata = meta
-							_ = portal.Save(ctx)
+							if err := portal.Save(ctx); err != nil {
+								zerolog.Ctx(ctx).Warn().Err(err).
+									Str("portal_id", string(portal.ID)).
+									Msg("Failed to persist IsSms metadata during initial sync")
+							}
 						}
 					}
 					close(done)

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -584,6 +584,9 @@ func (c *IMClient) loadSenderGuidsFromDB(log zerolog.Logger) {
 		return
 	}
 
+	// Migrate portal IDs that contain stale SMS suffixes before populating caches.
+	c.migrateSmsSuffixPortals(log, ctx, portals)
+
 	loadedGuids := 0
 	for _, portal := range portals {
 		if portal.Receiver != c.UserLogin.ID {
@@ -610,6 +613,66 @@ func (c *IMClient) loadSenderGuidsFromDB(log zerolog.Logger) {
 	}
 	if loadedGuids > 0 {
 		log.Info().Int("count", loadedGuids).Msg("Pre-populated sender_guid cache from database")
+	}
+}
+
+// migrateSmsSuffixPortals re-IDs portals whose IDs contain stale Apple SMS
+// suffixes like "(smsft)" or "(smsfp)". After stripSmsSuffix was added to
+// portal ID normalization, new lookups produce clean IDs, orphaning existing
+// portals that were created with the suffixed form. This runs once at startup
+// to reconcile old portal rows with the new normalized format.
+func (c *IMClient) migrateSmsSuffixPortals(log zerolog.Logger, ctx context.Context, portals []*bridgev2.Portal) {
+	migrated := 0
+	for _, portal := range portals {
+		if portal.Receiver != c.UserLogin.ID {
+			continue
+		}
+		oldID := string(portal.ID)
+
+		// Strip SMS suffixes from each member in the (possibly comma-separated) portal ID.
+		members := strings.Split(oldID, ",")
+		changed := false
+		for i, m := range members {
+			stripped := stripSmsSuffix(m)
+			if stripped != m {
+				members[i] = stripped
+				changed = true
+			}
+		}
+		if !changed {
+			continue
+		}
+
+		// Re-sort after stripping to maintain canonical order.
+		sort.Strings(members)
+		newID := strings.Join(members, ",")
+		if newID == oldID {
+			continue
+		}
+
+		oldKey := portal.PortalKey
+		newKey := networkid.PortalKey{
+			ID:       networkid.PortalID(newID),
+			Receiver: portal.Receiver,
+		}
+
+		result, _, err := c.reIDPortalWithCacheUpdate(ctx, oldKey, newKey)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("old_portal_id", oldID).
+				Str("new_portal_id", newID).
+				Msg("Failed to migrate SMS-suffixed portal ID")
+			continue
+		}
+		log.Info().
+			Str("old_portal_id", oldID).
+			Str("new_portal_id", newID).
+			Int("result", int(result)).
+			Msg("Migrated SMS-suffixed portal ID")
+		migrated++
+	}
+	if migrated > 0 {
+		log.Info().Int("count", migrated).Msg("Finished migrating SMS-suffixed portal IDs")
 	}
 }
 

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -878,7 +878,7 @@ func (c *IMClient) OnMessage(msg rustpushgo.WrappedMessage) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Error().Interface("panic", r).Msg("Panic in SendDeliveryReceipt")
+					log.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic in SendDeliveryReceipt")
 				}
 			}()
 			conv := c.makeConversation(msg.Participants, msg.GroupName)

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -7891,8 +7891,8 @@ func (c *IMClient) updatePortalSMS(portalID string, isSms bool) {
 func (c *IMClient) isPortalSMS(portalID string) bool {
 	c.smsPortalsLock.RLock()
 	defer c.smsPortalsLock.RUnlock()
-	if c.smsPortals[portalID] {
-		return true
+	if val, ok := c.smsPortals[portalID]; ok {
+		return val
 	}
 	// Fallback for legacy portals that still have the raw suffix in their ID
 	// (pre-fix DB entries that survive without a full reset). Such portals can

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -6433,7 +6433,12 @@ func (c *IMClient) ensureGroupPortalIndex() {
 
 // indexGroupPortalLocked adds a group portal ID to the in-memory index.
 // Caller must hold groupPortalMu write lock.
+// Safe to call before ensureGroupPortalIndex — returns early when the index
+// has not been built yet (nil map), since the full rebuild will pick it up.
 func (c *IMClient) indexGroupPortalLocked(portalID string) {
+	if c.groupPortalIndex == nil {
+		return
+	}
 	for _, member := range strings.Split(portalID, ",") {
 		if c.groupPortalIndex[member] == nil {
 			c.groupPortalIndex[member] = make(map[string]bool)

--- a/pkg/connector/dbmeta.go
+++ b/pkg/connector/dbmeta.go
@@ -16,6 +16,7 @@ type PortalMetadata struct {
 	ThreadID   string `json:"thread_id,omitempty"`
 	SenderGuid string `json:"sender_guid,omitempty"` // Persistent iMessage group UUID
 	GroupName  string `json:"group_name,omitempty"`   // iMessage cv_name for outbound routing
+	IsSms      bool   `json:"is_sms,omitempty"`       // True if this portal routes through SMS
 }
 
 type GhostMetadata struct{}

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -1697,6 +1697,13 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 			continue
 		}
 
+		// Mark SMS status in-memory so guards work immediately during this sync
+		// session. Persistence is handled by GetChatInfo ExtraUpdates when the
+		// portal is created/resynced via createPortalsFromCloudSync.
+		if strings.EqualFold(chat.Service, "SMS") {
+			c.updatePortalSMS(portalID, true)
+		}
+
 		participantsJSON, jsonErr := json.Marshal(chat.Participants)
 		if jsonErr != nil {
 			return counts, jsonErr
@@ -1886,6 +1893,10 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 // uuidPattern matches a UUID string (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// hexGroupPattern matches bare hex strings of 40+ characters (SHA1 hashes
+// used as CloudKit group identifiers for SMS groups).
+var hexGroupPattern = regexp.MustCompile(`(?i)^[0-9a-f]{40,}$`)
+
 // isNumericSuffix returns true if s is non-empty and contains only ASCII digits.
 // Used to identify CloudKit self-chat identifiers of the form "chat<digits>".
 func isNumericSuffix(s string) bool {
@@ -1920,6 +1931,12 @@ func (c *IMClient) resolveConversationID(ctx context.Context, msg rustpushgo.Wra
 
 	// Fallback: if no chat record exists yet, a UUID chat_id means group.
 	if msg.CloudChatId != "" && uuidPattern.MatchString(msg.CloudChatId) {
+		return "gid:" + strings.ToLower(msg.CloudChatId)
+	}
+
+	// Fallback: bare hex hash (40+ chars) — SMS group identifiers use SHA1
+	// hashes as their CloudKit chatID. These are always group chats.
+	if msg.CloudChatId != "" && hexGroupPattern.MatchString(msg.CloudChatId) {
 		return "gid:" + strings.ToLower(msg.CloudChatId)
 	}
 

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -1697,12 +1697,11 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 			continue
 		}
 
-		// Mark SMS status in-memory so guards work immediately during this sync
-		// session. Persistence is handled by GetChatInfo ExtraUpdates when the
+		// Update SMS status in-memory so guards work immediately during this sync
+		// session. Unconditional so SMS→iMessage transitions are reflected.
+		// Persistence is handled by GetChatInfo ExtraUpdates when the
 		// portal is created/resynced via createPortalsFromCloudSync.
-		if strings.EqualFold(chat.Service, "SMS") {
-			c.updatePortalSMS(portalID, true)
-		}
+		c.updatePortalSMS(portalID, strings.EqualFold(chat.Service, "SMS"))
 
 		participantsJSON, jsonErr := json.Marshal(chat.Participants)
 		if jsonErr != nil {

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -1697,11 +1697,13 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 			continue
 		}
 
-		// Update SMS status in-memory so guards work immediately during this sync
-		// session. Unconditional so SMS→iMessage transitions are reflected.
-		// Persistence is handled by GetChatInfo ExtraUpdates when the
-		// portal is created/resynced via createPortalsFromCloudSync.
-		c.updatePortalSMS(portalID, strings.EqualFold(chat.Service, "SMS"))
+		// Only mark portals as SMS from CloudKit records. We intentionally do
+		// NOT clear the SMS flag here for iMessage records because CloudKit can
+		// deliver stale iMessage records for legitimately-SMS portals. The live
+		// message path (handleMessage) handles SMS→iMessage transitions instead.
+		if strings.EqualFold(chat.Service, "SMS") {
+			c.updatePortalSMS(portalID, true)
+		}
 
 		participantsJSON, jsonErr := json.Marshal(chat.Participants)
 		if jsonErr != nil {

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -1895,7 +1895,7 @@ var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[
 
 // hexGroupPattern matches bare hex strings of 40+ characters (SHA1 hashes
 // used as CloudKit group identifiers for SMS groups).
-var hexGroupPattern = regexp.MustCompile(`(?i)^[0-9a-f]{40,}$`)
+var hexGroupPattern = regexp.MustCompile(`(?i)^[0-9a-f]{40,128}$`)
 
 // isNumericSuffix returns true if s is non-empty and contains only ASCII digits.
 // Used to identify CloudKit self-chat identifiers of the form "chat<digits>".

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -1697,12 +1697,14 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 			continue
 		}
 
-		// Only mark portals as SMS from CloudKit records. We intentionally do
-		// NOT clear the SMS flag here for iMessage records because CloudKit can
-		// deliver stale iMessage records for legitimately-SMS portals. The live
-		// message path (handleMessage) handles SMS→iMessage transitions instead.
+		// Update SMS flag from CloudKit chat service type. If a stale
+		// CloudKit record briefly clears the flag for a legitimately-SMS
+		// portal, the next live SMS message will re-set it immediately
+		// via handleMessage's unconditional updatePortalSMS call.
 		if strings.EqualFold(chat.Service, "SMS") {
 			c.updatePortalSMS(portalID, true)
+		} else if strings.EqualFold(chat.Service, "iMessage") {
+			c.updatePortalSMS(portalID, false)
 		}
 
 		participantsJSON, jsonErr := json.Marshal(chat.Participants)

--- a/pkg/connector/util.go
+++ b/pkg/connector/util.go
@@ -54,6 +54,15 @@ func stripNonBase64(s string) string {
 	return b.String()
 }
 
+// stripSmsSuffix removes Apple SMS service suffixes such as "(smsfp)" or
+// "(smsft)" that appear on identifiers in chat.db.
+func stripSmsSuffix(id string) string {
+	if idx := strings.Index(id, "(sms"); idx > 0 {
+		return id[:idx]
+	}
+	return id
+}
+
 // stripIdentifierPrefix removes tel: or mailto: prefix from an identifier.
 func stripIdentifierPrefix(id string) string {
 	id = strings.TrimPrefix(id, "tel:")

--- a/pkg/connector/util.go
+++ b/pkg/connector/util.go
@@ -58,7 +58,10 @@ func stripNonBase64(s string) string {
 // "(smsft)" that appear on identifiers in chat.db.
 func stripSmsSuffix(id string) string {
 	if idx := strings.Index(id, "(sms"); idx > 0 {
-		return id[:idx]
+		// Verify the suffix is at the end of the string with a closing paren.
+		if closeIdx := strings.Index(id[idx:], ")"); closeIdx >= 0 && idx+closeIdx+1 == len(id) {
+			return id[:idx]
+		}
 	}
 	return id
 }


### PR DESCRIPTION
## Title
fix(connector): stabilize SMS and RCS portal handling

## Summary
This fixes SMS/RCS portal correctness across CloudKit sync, restart recovery, live handling, and the remaining chat.db-derived identifier gaps.

## Changes
- resolve SHA1-style CloudKit SMS group IDs to `gid:...`
- persist `PortalMetadata.IsSms` and restore SMS state on restart
- normalize legacy `(sms...)` suffixes consistently in shared and chat.db-derived paths
- skip iMessage-only handlers for SMS/RCS portals
- keep the existing FFI hardening changes, without the local `CLAUDE.md` addition

## Notes
- This intentionally includes a few chat.db-only support hunks because they complete the overall SMS/RCS correctness story.
- No Live Photo behavior is changed here.
