### PR TITLE
fix(backfill): canonicalize DM senders consistently

### DIFF
--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -188,6 +188,7 @@ func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessag
 			continue
 		}
 		sender := chatDBMakeEventSender(msg, c)
+		sender = c.canonicalizeDMSender(params.Portal.PortalKey, sender)
 
 		// Strip U+FFFC (object replacement character) — inline attachment
 		// placeholders from NSAttributedString that render as blank

--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -188,6 +188,9 @@ func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessag
 			continue
 		}
 		sender := chatDBMakeEventSender(msg, c)
+		if sender.Sender == "" && !sender.IsFromMe {
+			continue
+		}
 		sender = c.canonicalizeDMSender(params.Portal.PortalKey, sender)
 
 		// Strip U+FFFC (object replacement character) — inline attachment

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4915,6 +4915,7 @@ func (c *IMClient) cloudRowsToBackfillMessages(ctx context.Context, rows []cloud
 		if sender.Sender == "" && !sender.IsFromMe {
 			continue
 		}
+		sender = c.canonicalizeDMSender(networkid.PortalKey{ID: networkid.PortalID(row.PortalID)}, sender)
 
 		tapbackType := *row.TapbackType
 		isRemove := tapbackType >= 3000
@@ -4961,6 +4962,7 @@ func (c *IMClient) cloudRowToBackfillMessages(ctx context.Context, row cloudMess
 	if sender.Sender == "" && !sender.IsFromMe {
 		return nil
 	}
+	sender = c.canonicalizeDMSender(networkid.PortalKey{ID: networkid.PortalID(row.PortalID)}, sender)
 
 	// Skip system/service messages (group renames, participant changes, etc.).
 	// Two complementary signals:

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -561,8 +561,9 @@ func (c *IMClient) onForwardBackfillDone() {
 		// refreshGhostNamesFromContacts call (triggered by setContactsReady)
 		// may have scanned the DB before backfill ghosts existed, leaving them
 		// with fallback display names. Multi-handle contacts are especially
-		// affected because makeCloudSender does not call canonicalizeDMSender,
-		// creating phantom sender ghosts that also need display names set.
+		// affected because canonicalizeDMSender only remaps within the same
+		// portal, so multi-handle senders still create additional ghosts
+		// that also need display names set.
 		c.contactsReadyLock.RLock()
 		contactsReady := c.contactsReady
 		c.contactsReadyLock.RUnlock()


### PR DESCRIPTION
## Title
fix(backfill): canonicalize DM senders consistently

## Summary
Backfill paths should resolve DM senders the same way as live traffic. This applies canonical sender remapping to CloudKit and chat.db backfill while still dropping senderless system rows before remapping.

## Changes
- canonicalize DM senders in CloudKit backfill rows
- canonicalize DM senders in chat.db backfill rows
- preserve the empty-sender guard ordering in CloudKit paths

## Notes
- Scope is intentionally small.
