### PR TITLE
fix(groups): preserve authoritative names and stable gid aliases

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4203,7 +4203,7 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 		// names to stale values from CloudKit or metadata, and produce
 		// unwanted bridge bot "name changed" events.
 		if portal.MXID == "" || portal.Name == "" {
-			groupName, _ := c.resolveGroupName(ctx, portalID)
+			groupName := c.resolveGroupName(ctx, portalID)
 			chatInfo.Name = &groupName
 		}
 
@@ -7256,28 +7256,28 @@ func (c *IMClient) resolveGroupMembers(ctx context.Context, portalID string) []s
 //	2) CloudKit display_name (user-set group name persisted to iCloud,
 //	   the "name" field on CKChatRecord = cv_name from chat.db)
 //	3) contact-resolved member names via buildGroupName (non-authoritative)
-func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) (string, bool) {
+func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) string {
 	// 1) In-memory cache (populated from real-time iMessage rename messages)
 	c.imGroupNamesMu.RLock()
 	name := c.imGroupNames[portalID]
 	c.imGroupNamesMu.RUnlock()
 	if name != "" {
-		return name, true
+		return name
 	}
 
 	// 2) CloudKit display_name (user-set group name from iCloud).
 	if c.cloudStore != nil {
 		if dn, err := c.cloudStore.getDisplayNameByPortalID(ctx, portalID); err == nil && dn != "" {
-			return dn, true
+			return dn
 		}
 	}
 
 	// 3) Build from contact-resolved member names (fallback, non-authoritative)
 	members := c.resolveGroupMembers(ctx, portalID)
 	if len(members) == 0 {
-		return "Group Chat", false
+		return "Group Chat"
 	}
-	return c.buildGroupName(members), false
+	return c.buildGroupName(members)
 }
 
 // buildGroupName creates a human-readable group name from member identifiers

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -6582,14 +6582,24 @@ func (c *IMClient) findGroupPortalForMember(member string) (networkid.PortalKey,
 }
 
 // guidCacheMatchIsStale returns true if a guid cache entry for a comma-based
-// portal is provably stale — the portal ID's participants don't match the
-// incoming message's participants. Returns false (not provably stale) for
-// non-comma portals, when no participant info is available, or when participants match.
+// portal is provably stale — the incoming participants contain members not
+// present in the cached portal. Returns false (not provably stale) for
+// non-comma portals, when no participant info is available, or when all
+// incoming participants are present in the portal's member set.
+//
+// This intentionally uses a subset check rather than a symmetric match:
+// typing and read-receipt payloads may only include [sender, target] without
+// the full group roster, so missing portal members are expected and do not
+// indicate staleness.
 func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []string) bool {
 	if !strings.Contains(portalIDStr, ",") || len(rawParticipants) == 0 {
 		return false
 	}
 	portalParts := strings.Split(portalIDStr, ",")
+	portalSet := make(map[string]bool, len(portalParts))
+	for _, p := range portalParts {
+		portalSet[p] = true
+	}
 	// Canonicalize incoming participants (collapses alternate self handles
 	// to c.handle, deduplicates, sorts) so all callsites get consistent
 	// behavior regardless of whether they pre-canonicalize.
@@ -6597,7 +6607,15 @@ func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []s
 	if len(canonical) == 0 {
 		return false
 	}
-	return !participantSetsMatch(portalParts, canonical, c.isMyHandle)
+	// Only flag as stale if incoming participants contain members NOT in
+	// the portal's set (and not self handles). This correctly handles
+	// partial payloads where the incoming list is a subset of the portal.
+	for _, p := range canonical {
+		if !portalSet[p] && !c.isMyHandle(p) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveExistingGroupByGid tries to find an existing group portal that matches

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -6592,10 +6592,23 @@ func (c *IMClient) findGroupPortalForMember(member string) (networkid.PortalKey,
 // the full group roster, so missing portal members are expected and do not
 // indicate staleness.
 func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []string) bool {
-	if !strings.Contains(portalIDStr, ",") || len(rawParticipants) == 0 {
+	if len(rawParticipants) == 0 {
 		return false
 	}
-	portalParts := strings.Split(portalIDStr, ",")
+	// For gid: portal IDs (no comma), resolve participants from the cache
+	// so gid->gid aliases can be validated and self-heal when stale.
+	var portalParts []string
+	if !strings.Contains(portalIDStr, ",") {
+		c.imGroupParticipantsMu.RLock()
+		cached := c.imGroupParticipants[portalIDStr]
+		c.imGroupParticipantsMu.RUnlock()
+		if len(cached) == 0 {
+			return false // no participant info to compare against
+		}
+		portalParts = cached
+	} else {
+		portalParts = strings.Split(portalIDStr, ",")
+	}
 	portalSet := make(map[string]bool, len(portalParts))
 	for _, p := range portalParts {
 		portalSet[p] = true

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1907,7 +1907,11 @@ func (c *IMClient) makeDeletePortalKey(log zerolog.Logger, msg rustpushgo.Wrappe
 		if hasAlias {
 			if c.guidCacheMatchIsStale(aliasedID, msg.DeleteChatParticipants) {
 				c.gidAliasesMu.Lock()
-				delete(c.gidAliases, gidID)
+				// Compare-before-delete: another handler may have repaired
+				// the alias between our RLock read and this write lock.
+				if c.gidAliases[gidID] == aliasedID {
+					delete(c.gidAliases, gidID)
+				}
 				c.gidAliasesMu.Unlock()
 				log.Warn().
 					Str("gid_id", gidID).
@@ -6586,16 +6590,14 @@ func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []s
 		return false
 	}
 	portalParts := strings.Split(portalIDStr, ",")
-	incomingParts := make([]string, 0, len(rawParticipants))
-	for _, p := range rawParticipants {
-		if n := normalizeIdentifierForPortalID(p); n != "" {
-			incomingParts = append(incomingParts, n)
-		}
-	}
-	if len(incomingParts) == 0 {
+	// Canonicalize incoming participants (collapses alternate self handles
+	// to c.handle, deduplicates, sorts) so all callsites get consistent
+	// behavior regardless of whether they pre-canonicalize.
+	canonical := c.buildCanonicalParticipantList(rawParticipants)
+	if len(canonical) == 0 {
 		return false
 	}
-	return !participantSetsMatch(portalParts, incomingParts, c.isMyHandle)
+	return !participantSetsMatch(portalParts, canonical, c.isMyHandle)
 }
 
 // resolveExistingGroupByGid tries to find an existing group portal that matches

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1635,10 +1635,10 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 	}
 
 	// Cache sender_guid and group_name under the (possibly new) portal ID.
-	// Mirror the guard from Site B (makePortalKey): only cache for comma-based
-	// portals and for gid: portals where the portal ID directly corresponds to
-	// this sender_guid. This prevents participant-change messages from poisoning
-	// the cache when a prior mis-routing led to a wrong finalPortalKey.
+	// For comma-based portals and gid: portals, cache the sender_guid so
+	// future messages can be resolved to this portal. This is skipped for
+	// other portal ID formats to avoid poisoning the cache with unrelated
+	// sender_guids.
 	if msg.SenderGuid != nil && *msg.SenderGuid != "" {
 		portalIDStr := string(finalPortalKey.ID)
 		isGidPortal := strings.HasPrefix(portalIDStr, "gid:")

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4203,7 +4203,7 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 		// names to stale values from CloudKit or metadata, and produce
 		// unwanted bridge bot "name changed" events.
 		if portal.MXID == "" || portal.Name == "" {
-			groupName := c.resolveGroupName(ctx, portalID)
+			groupName, _ := c.resolveGroupName(ctx, portalID)
 			chatInfo.Name = &groupName
 		}
 
@@ -7256,28 +7256,28 @@ func (c *IMClient) resolveGroupMembers(ctx context.Context, portalID string) []s
 //	2) CloudKit display_name (user-set group name persisted to iCloud,
 //	   the "name" field on CKChatRecord = cv_name from chat.db)
 //	3) contact-resolved member names via buildGroupName (non-authoritative)
-func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) string {
+func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) (name string, authoritative bool) {
 	// 1) In-memory cache (populated from real-time iMessage rename messages)
 	c.imGroupNamesMu.RLock()
-	name := c.imGroupNames[portalID]
+	cached := c.imGroupNames[portalID]
 	c.imGroupNamesMu.RUnlock()
-	if name != "" {
-		return name
+	if cached != "" {
+		return cached, true
 	}
 
 	// 2) CloudKit display_name (user-set group name from iCloud).
 	if c.cloudStore != nil {
 		if dn, err := c.cloudStore.getDisplayNameByPortalID(ctx, portalID); err == nil && dn != "" {
-			return dn
+			return dn, true
 		}
 	}
 
 	// 3) Build from contact-resolved member names (fallback, non-authoritative)
 	members := c.resolveGroupMembers(ctx, portalID)
 	if len(members) == 0 {
-		return "Group Chat"
+		return "Group Chat", false
 	}
-	return c.buildGroupName(members)
+	return c.buildGroupName(members), false
 }
 
 // buildGroupName creates a human-readable group name from member identifiers

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1641,8 +1641,8 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 	// the cache when a prior mis-routing led to a wrong finalPortalKey.
 	if msg.SenderGuid != nil && *msg.SenderGuid != "" {
 		portalIDStr := string(finalPortalKey.ID)
-		isOwnGidPortal := portalIDStr == "gid:"+strings.ToLower(*msg.SenderGuid)
-		if strings.Contains(portalIDStr, ",") || isOwnGidPortal {
+		isGidPortal := strings.HasPrefix(portalIDStr, "gid:")
+		if strings.Contains(portalIDStr, ",") || isGidPortal {
 			c.imGroupGuidsMu.Lock()
 			c.imGroupGuids[portalIDStr] = *msg.SenderGuid
 			c.imGroupGuidsMu.Unlock()

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1606,22 +1606,7 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 
 	// Compute new portal ID from the NEW participant list using the same
 	// normalization / dedup / sort logic as makePortalKey's group branch.
-	sorted := make([]string, 0, len(msg.NewParticipants))
-	for _, p := range msg.NewParticipants {
-		normalized := normalizeIdentifierForPortalID(p)
-		if normalized == "" || c.isMyHandle(normalized) {
-			continue
-		}
-		sorted = append(sorted, normalized)
-	}
-	sorted = append(sorted, normalizeIdentifierForPortalID(c.handle))
-	sort.Strings(sorted)
-	deduped := sorted[:0]
-	for i, s := range sorted {
-		if i == 0 || s != sorted[i-1] {
-			deduped = append(deduped, s)
-		}
-	}
+	deduped := c.buildCanonicalParticipantList(msg.NewParticipants)
 	newPortalIDStr := strings.Join(deduped, ",")
 	oldPortalIDStr := string(oldPortalKey.ID)
 
@@ -1650,10 +1635,18 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 	}
 
 	// Cache sender_guid and group_name under the (possibly new) portal ID.
+	// Mirror the guard from Site B (makePortalKey): only cache for comma-based
+	// portals and for gid: portals where the portal ID directly corresponds to
+	// this sender_guid. This prevents participant-change messages from poisoning
+	// the cache when a prior mis-routing led to a wrong finalPortalKey.
 	if msg.SenderGuid != nil && *msg.SenderGuid != "" {
-		c.imGroupGuidsMu.Lock()
-		c.imGroupGuids[string(finalPortalKey.ID)] = *msg.SenderGuid
-		c.imGroupGuidsMu.Unlock()
+		portalIDStr := string(finalPortalKey.ID)
+		isOwnGidPortal := portalIDStr == "gid:"+strings.ToLower(*msg.SenderGuid)
+		if strings.Contains(portalIDStr, ",") || isOwnGidPortal {
+			c.imGroupGuidsMu.Lock()
+			c.imGroupGuids[portalIDStr] = *msg.SenderGuid
+			c.imGroupGuidsMu.Unlock()
+		}
 	}
 	if msg.GroupName != nil && *msg.GroupName != "" {
 		c.imGroupNamesMu.Lock()
@@ -1912,8 +1905,19 @@ func (c *IMClient) makeDeletePortalKey(log zerolog.Logger, msg rustpushgo.Wrappe
 		aliasedID, hasAlias := c.gidAliases[gidID]
 		c.gidAliasesMu.RUnlock()
 		if hasAlias {
-			portalKey.ID = networkid.PortalID(aliasedID)
-			return portalKey
+			if c.guidCacheMatchIsStale(aliasedID, msg.DeleteChatParticipants) {
+				c.gidAliasesMu.Lock()
+				delete(c.gidAliases, gidID)
+				c.gidAliasesMu.Unlock()
+				log.Warn().
+					Str("gid_id", gidID).
+					Str("stale_alias", aliasedID).
+					Msg("Cleared stale gid alias in handleDeleteChat: participant mismatch")
+				// Fall through to direct gid: lookup / resolveExistingGroupByGid
+			} else {
+				portalKey.ID = networkid.PortalID(aliasedID)
+				return portalKey
+			}
 		}
 		if existing, _ := c.Main.Bridge.GetExistingPortalByKey(ctx, portalKey); existing != nil && existing.MXID != "" {
 			return portalKey
@@ -3194,7 +3198,10 @@ func (c *IMClient) handleReadReceipt(log zerolog.Logger, msg rustpushgo.WrappedM
 		}
 		c.imGroupGuidsMu.RLock()
 		for portalIDStr, guid := range c.imGroupGuids {
-			if guid == *msg.SenderGuid {
+			if strings.EqualFold(guid, *msg.SenderGuid) {
+				if c.guidCacheMatchIsStale(portalIDStr, msg.Participants) {
+					continue
+				}
 				portalKey = networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
 				c.imGroupGuidsMu.RUnlock()
 				log.Debug().
@@ -3343,7 +3350,10 @@ func (c *IMClient) handleTyping(log zerolog.Logger, msg rustpushgo.WrappedMessag
 		// Fall back to cache lookup for legacy portals
 		c.imGroupGuidsMu.RLock()
 		for portalIDStr, guid := range c.imGroupGuids {
-			if guid == *msg.SenderGuid {
+			if strings.EqualFold(guid, *msg.SenderGuid) {
+				if c.guidCacheMatchIsStale(portalIDStr, msg.Participants) {
+					continue
+				}
 				portalKey = networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
 				c.imGroupGuidsMu.RUnlock()
 				log.Debug().
@@ -4189,7 +4199,7 @@ func (c *IMClient) GetChatInfo(ctx context.Context, portal *bridgev2.Portal) (*b
 		// names to stale values from CloudKit or metadata, and produce
 		// unwanted bridge bot "name changed" events.
 		if portal.MXID == "" || portal.Name == "" {
-			groupName := c.resolveGroupName(ctx, portalID)
+			groupName, _ := c.resolveGroupName(ctx, portalID)
 			chatInfo.Name = &groupName
 		}
 
@@ -6120,6 +6130,31 @@ func normalizeIdentifierForPortalID(identifier string) string {
 	return id
 }
 
+// buildCanonicalParticipantList normalizes, deduplicates, and sorts a
+// participant list into the canonical form used for comma-based portal IDs.
+// Any self handles are filtered out and replaced with the single canonical
+// c.handle. Accepts both raw and pre-normalized inputs (normalization is
+// idempotent).
+func (c *IMClient) buildCanonicalParticipantList(participants []string) []string {
+	sorted := make([]string, 0, len(participants))
+	for _, p := range participants {
+		normalized := normalizeIdentifierForPortalID(p)
+		if normalized == "" || c.isMyHandle(normalized) {
+			continue
+		}
+		sorted = append(sorted, normalized)
+	}
+	sorted = append(sorted, normalizeIdentifierForPortalID(c.handle))
+	sort.Strings(sorted)
+	deduped := sorted[:0]
+	for i, s := range sorted {
+		if i == 0 || s != sorted[i-1] {
+			deduped = append(deduped, s)
+		}
+	}
+	return deduped
+}
+
 // normalizePhoneIdentifierForPortalID canonicalizes phone-like identifiers while
 // preserving short-code semantics (e.g. "242733" stays "242733", not "+242733").
 func normalizePhoneIdentifierForPortalID(local string) string {
@@ -6397,10 +6432,14 @@ func (c *IMClient) resolveExistingGroupPortalID(computedID string, senderGuid *s
 	c.groupPortalMu.RUnlock()
 
 	for existingID, sharedCount := range overlap {
-		existingSize := len(strings.Split(existingID, ","))
+		existingMembers := strings.Split(existingID, ",")
+		existingSize := len(existingMembers)
 		diff := (candidateSize - sharedCount) + (existingSize - sharedCount)
 		if diff > 1 {
 			continue
+		}
+		if diff == 1 && !participantSetsMatch(candidateMembers, existingMembers, c.handle) {
+			continue // diff=1 for a non-self member → different group
 		}
 
 		// If we have a sender_guid, reject fuzzy matches with a different
@@ -6538,6 +6577,27 @@ func (c *IMClient) findGroupPortalForMember(member string) (networkid.PortalKey,
 	return networkid.PortalKey{}, false
 }
 
+// guidCacheMatchIsStale returns true if a guid cache entry for a comma-based
+// portal is provably stale — the portal ID's participants don't match the
+// incoming message's participants. Returns false (not provably stale) for
+// non-comma portals, when no participant info is available, or when participants match.
+func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []string) bool {
+	if !strings.Contains(portalIDStr, ",") || len(rawParticipants) == 0 {
+		return false
+	}
+	portalParts := strings.Split(portalIDStr, ",")
+	incomingParts := make([]string, 0, len(rawParticipants))
+	for _, p := range rawParticipants {
+		if n := normalizeIdentifierForPortalID(p); n != "" {
+			incomingParts = append(incomingParts, n)
+		}
+	}
+	if len(incomingParts) == 0 {
+		return false
+	}
+	return !participantSetsMatch(portalParts, incomingParts, c.handle)
+}
+
 // resolveExistingGroupByGid tries to find an existing group portal that matches
 // the incoming message when the gid (sender_guid) doesn't match any known portal.
 // This handles the case where another rustpush client (like OpenBubbles) uses a
@@ -6559,6 +6619,45 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	for portalIDStr, guid := range c.imGroupGuids {
 		if strings.ToLower(guid) == normalizedGuid {
 			c.imGroupGuidsMu.RUnlock()
+			if c.guidCacheMatchIsStale(portalIDStr, participants) {
+				c.UserLogin.Log.Warn().
+					Str("gid_portal_id", gidPortalID).
+					Str("candidate_portal", portalIDStr).
+					Str("stale_guid", guid).
+					Msg("Skipping stale guid cache entry: participant mismatch — clearing")
+				// Self-heal: remove from in-memory cache
+				c.imGroupGuidsMu.Lock()
+				if c.imGroupGuids[portalIDStr] == guid {
+					delete(c.imGroupGuids, portalIDStr)
+				}
+				c.imGroupGuidsMu.Unlock()
+				// Self-heal: clear stale SenderGuid from DB metadata.
+				// MUST be synchronous — portalToConversation (Site E) lazily
+				// loads metadata into cache and would re-poison it.
+				staleKey := networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
+				if stalePortal, err := c.Main.Bridge.GetExistingPortalByKey(ctx, staleKey); err != nil {
+					c.UserLogin.Log.Warn().Err(err).
+						Str("portal_id", portalIDStr).
+						Msg("Failed to look up portal for stale guid self-heal")
+				} else if stalePortal != nil {
+					if meta, ok := stalePortal.Metadata.(*PortalMetadata); ok && meta.SenderGuid == guid {
+						meta.SenderGuid = ""
+						stalePortal.Metadata = meta
+						if err := stalePortal.Save(ctx); err != nil {
+							c.UserLogin.Log.Warn().Err(err).
+								Str("portal_id", portalIDStr).
+								Msg("Failed to clear stale SenderGuid from DB metadata")
+						} else {
+							c.UserLogin.Log.Info().
+								Str("portal_id", portalIDStr).
+								Str("cleared_guid", guid).
+								Msg("Cleared stale SenderGuid from DB metadata")
+						}
+					}
+				}
+				c.imGroupGuidsMu.RLock()
+				continue
+			}
 			key := networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
 			if p, _ := c.Main.Bridge.GetExistingPortalByKey(ctx, key); p != nil && p.MXID != "" {
 				c.UserLogin.Log.Info().
@@ -6587,18 +6686,19 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 		return networkid.PortalID(gidPortalID)
 	}
 
-	// 2. Check imGroupParticipants cache: find portals (including other gid:
-	//    portals) with matching participant sets. Skip DM portals — they
-	//    can accidentally match via ±1 participant tolerance.
+	// 2. Check imGroupParticipants cache: find gid: portals with matching
+	//    participant sets. Comma-based portals are intentionally excluded here
+	//    because step 3 (groupPortalIndex) handles them using the authoritative
+	//    portal ID rather than the potentially-stale in-memory cache.
 	c.imGroupParticipantsMu.RLock()
 	for portalIDStr, parts := range c.imGroupParticipants {
 		if portalIDStr == gidPortalID {
 			continue
 		}
-		if !strings.HasPrefix(portalIDStr, "gid:") && !strings.Contains(portalIDStr, ",") {
+		if !strings.HasPrefix(portalIDStr, "gid:") {
 			continue
 		}
-		if participantSetsMatch(parts, normalizedParts) {
+		if participantSetsMatch(parts, normalizedParts, c.handle) {
 			c.imGroupParticipantsMu.RUnlock()
 			key := networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
 			if p, _ := c.Main.Bridge.GetExistingPortalByKey(ctx, key); p != nil && p.MXID != "" {
@@ -6618,20 +6718,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	//    whole point is to find portals where the guid differs (another client
 	//    using a different gid for the same group).
 	c.ensureGroupPortalIndex()
-	sorted := make([]string, 0, len(normalizedParts))
-	for _, p := range normalizedParts {
-		if !c.isMyHandle(p) {
-			sorted = append(sorted, p)
-		}
-	}
-	sorted = append(sorted, normalizeIdentifierForPortalID(c.handle))
-	sort.Strings(sorted)
-	deduped := sorted[:0]
-	for i, s := range sorted {
-		if i == 0 || s != sorted[i-1] {
-			deduped = append(deduped, s)
-		}
-	}
+	deduped := c.buildCanonicalParticipantList(normalizedParts)
 
 	overlap := make(map[string]int)
 	c.groupPortalMu.RLock()
@@ -6643,21 +6730,43 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	c.groupPortalMu.RUnlock()
 
 	candidateSize := len(deduped)
+	var exactMatch, fuzzyMatch string
 	for existingID, sharedCount := range overlap {
-		existingSize := len(strings.Split(existingID, ","))
+		existingMembers := strings.Split(existingID, ",")
+		existingSize := len(existingMembers)
 		diff := (candidateSize - sharedCount) + (existingSize - sharedCount)
 		if diff > 1 {
 			continue
 		}
+		if diff == 1 && !participantSetsMatch(deduped, existingMembers, c.handle) {
+			continue // diff=1 for a non-self member → different group
+		}
 		key := networkid.PortalKey{ID: networkid.PortalID(existingID), Receiver: c.UserLogin.ID}
 		if p, _ := c.Main.Bridge.GetExistingPortalByKey(ctx, key); p != nil && p.MXID != "" {
-			c.UserLogin.Log.Info().
-				Str("gid_portal_id", gidPortalID).
-				Str("resolved_portal", existingID).
-				Int("participant_diff", diff).
-				Msg("Resolved unknown gid to existing comma-based portal via fuzzy match")
-			return networkid.PortalID(existingID)
+			if diff == 0 {
+				exactMatch = existingID
+				break // Can't do better than exact
+			}
+			if fuzzyMatch == "" {
+				fuzzyMatch = existingID
+			}
 		}
+	}
+	if exactMatch != "" {
+		c.UserLogin.Log.Info().
+			Str("gid_portal_id", gidPortalID).
+			Str("resolved_portal", exactMatch).
+			Int("participant_diff", 0).
+			Msg("Resolved unknown gid to existing comma-based portal via fuzzy match")
+		return networkid.PortalID(exactMatch)
+	}
+	if fuzzyMatch != "" {
+		c.UserLogin.Log.Info().
+			Str("gid_portal_id", gidPortalID).
+			Str("resolved_portal", fuzzyMatch).
+			Int("participant_diff", 1).
+			Msg("Resolved unknown gid to existing comma-based portal via fuzzy match")
+		return networkid.PortalID(fuzzyMatch)
 	}
 
 	// 4. Fall back to cloud_chat DB for portals not in memory caches
@@ -6667,7 +6776,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	//    can accidentally match via ±1 participant tolerance because a
 	//    DM's [self, A] is one member short of a group's [self, A, B].
 	if c.cloudStore != nil {
-		matches, err := c.cloudStore.findPortalIDsByParticipants(ctx, normalizedParts)
+		matches, err := c.cloudStore.findPortalIDsByParticipants(ctx, normalizedParts, c.handle)
 		if err == nil {
 			for _, matchPortalID := range matches {
 				if matchPortalID == gidPortalID {
@@ -6711,8 +6820,31 @@ func (c *IMClient) makePortalKey(participants []string, groupName *string, sende
 			aliasedID, hasAlias := c.gidAliases[gidID]
 			c.gidAliasesMu.RUnlock()
 			if hasAlias {
-				portalID = networkid.PortalID(aliasedID)
-			} else {
+				// Canonicalize participants (collapses alternate self handles to
+				// c.handle) before staleness check so a valid alias is never
+				// evicted just because APNs reported self with a different identifier.
+				// Guard on raw participants first: buildCanonicalParticipantList always
+				// injects c.handle, so canonical is never empty even when the message
+				// carried no participant info — a [self]-only list must not trigger eviction.
+				canonical := c.buildCanonicalParticipantList(participants)
+				if len(participants) > 0 && len(canonical) > 0 && c.guidCacheMatchIsStale(aliasedID, canonical) {
+					c.gidAliasesMu.Lock()
+					// Compare-before-delete: another handler may have repaired
+					// the alias between our RLock read and this write lock.
+					if c.gidAliases[gidID] == aliasedID {
+						delete(c.gidAliases, gidID)
+					}
+					c.gidAliasesMu.Unlock()
+					c.UserLogin.Log.Warn().
+						Str("gid_id", gidID).
+						Str("stale_alias", aliasedID).
+						Msg("Cleared stale gid alias: participant mismatch")
+					// Fall through to normal resolution below
+				} else {
+					portalID = networkid.PortalID(aliasedID)
+				}
+			}
+			if portalID == "" {
 				// Check if a portal with this exact gid already exists.
 				ctx := context.Background()
 				gidKey := networkid.PortalKey{ID: networkid.PortalID(gidID), Receiver: c.UserLogin.ID}
@@ -6734,24 +6866,8 @@ func (c *IMClient) makePortalKey(participants []string, groupName *string, sende
 			}
 		} else {
 			// Fallback: build a participant-based ID for groups without a UUID.
-			sorted := make([]string, 0, len(participants))
-			for _, p := range participants {
-				normalized := normalizeIdentifierForPortalID(p)
-				if normalized == "" || c.isMyHandle(normalized) {
-					continue
-				}
-				sorted = append(sorted, normalized)
-			}
-			sorted = append(sorted, normalizeIdentifierForPortalID(c.handle))
-			sort.Strings(sorted)
-			deduped := sorted[:0]
-			for i, s := range sorted {
-				if i == 0 || s != sorted[i-1] {
-					deduped = append(deduped, s)
-				}
-			}
-			sorted = deduped
-			computedID := strings.Join(sorted, ",")
+			deduped := c.buildCanonicalParticipantList(participants)
+			computedID := strings.Join(deduped, ",")
 			portalID = c.resolveExistingGroupPortalID(computedID, senderGuid)
 		}
 		// Cache the actual iMessage group name (cv_name) so outbound
@@ -7098,34 +7214,37 @@ func (c *IMClient) resolveGroupMembers(ctx context.Context, portalID string) []s
 }
 
 // resolveGroupName determines the best display name for a group portal.
+// Returns the name and whether it came from an authoritative source
+// (imGroupNames cache or CloudKit display_name). When authoritative is
+// false, the name was generated from contact-resolved participant names.
 // Priority: 1) in-memory cache (user-set iMessage group name from real-time
 //
 //	   protocol cv_name, e.g. when someone explicitly renames a group)
 //	2) CloudKit display_name (user-set group name persisted to iCloud,
 //	   the "name" field on CKChatRecord = cv_name from chat.db)
-//	3) contact-resolved member names via buildGroupName
-func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) string {
+//	3) contact-resolved member names via buildGroupName (non-authoritative)
+func (c *IMClient) resolveGroupName(ctx context.Context, portalID string) (string, bool) {
 	// 1) In-memory cache (populated from real-time iMessage rename messages)
 	c.imGroupNamesMu.RLock()
 	name := c.imGroupNames[portalID]
 	c.imGroupNamesMu.RUnlock()
 	if name != "" {
-		return name
+		return name, true
 	}
 
 	// 2) CloudKit display_name (user-set group name from iCloud).
 	if c.cloudStore != nil {
 		if dn, err := c.cloudStore.getDisplayNameByPortalID(ctx, portalID); err == nil && dn != "" {
-			return dn
+			return dn, true
 		}
 	}
 
-	// 3) Build from contact-resolved member names
+	// 3) Build from contact-resolved member names (fallback, non-authoritative)
 	members := c.resolveGroupMembers(ctx, portalID)
 	if len(members) == 0 {
-		return "Group Chat"
+		return "Group Chat", false
 	}
-	return c.buildGroupName(members)
+	return c.buildGroupName(members), false
 }
 
 // buildGroupName creates a human-readable group name from member identifiers

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -6438,7 +6438,7 @@ func (c *IMClient) resolveExistingGroupPortalID(computedID string, senderGuid *s
 		if diff > 1 {
 			continue
 		}
-		if diff == 1 && !participantSetsMatch(candidateMembers, existingMembers, c.handle) {
+		if diff == 1 && !participantSetsMatch(candidateMembers, existingMembers, c.isMyHandle) {
 			continue // diff=1 for a non-self member → different group
 		}
 
@@ -6595,7 +6595,7 @@ func (c *IMClient) guidCacheMatchIsStale(portalIDStr string, rawParticipants []s
 	if len(incomingParts) == 0 {
 		return false
 	}
-	return !participantSetsMatch(portalParts, incomingParts, c.handle)
+	return !participantSetsMatch(portalParts, incomingParts, c.isMyHandle)
 }
 
 // resolveExistingGroupByGid tries to find an existing group portal that matches
@@ -6698,7 +6698,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 		if !strings.HasPrefix(portalIDStr, "gid:") {
 			continue
 		}
-		if participantSetsMatch(parts, normalizedParts, c.handle) {
+		if participantSetsMatch(parts, normalizedParts, c.isMyHandle) {
 			c.imGroupParticipantsMu.RUnlock()
 			key := networkid.PortalKey{ID: networkid.PortalID(portalIDStr), Receiver: c.UserLogin.ID}
 			if p, _ := c.Main.Bridge.GetExistingPortalByKey(ctx, key); p != nil && p.MXID != "" {
@@ -6738,7 +6738,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 		if diff > 1 {
 			continue
 		}
-		if diff == 1 && !participantSetsMatch(deduped, existingMembers, c.handle) {
+		if diff == 1 && !participantSetsMatch(deduped, existingMembers, c.isMyHandle) {
 			continue // diff=1 for a non-self member → different group
 		}
 		key := networkid.PortalKey{ID: networkid.PortalID(existingID), Receiver: c.UserLogin.ID}
@@ -6776,7 +6776,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	//    can accidentally match via ±1 participant tolerance because a
 	//    DM's [self, A] is one member short of a group's [self, A, B].
 	if c.cloudStore != nil {
-		matches, err := c.cloudStore.findPortalIDsByParticipants(ctx, normalizedParts, c.handle)
+		matches, err := c.cloudStore.findPortalIDsByParticipants(ctx, normalizedParts, c.isMyHandle)
 		if err == nil {
 			for _, matchPortalID := range matches {
 				if matchPortalID == gidPortalID {

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -1993,7 +1993,7 @@ func (s *cloudBackfillStore) portalHasPreStartupOutgoingMessages(ctx context.Con
 // whose participants overlap with the given normalized participant list.
 // Used to find duplicate group portals that have the same members but different
 // group UUIDs. Participants are compared after normalization (tel:/mailto: prefix).
-func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, normalizedTarget []string) ([]string, error) {
+func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, normalizedTarget []string, selfHandle string) ([]string, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT DISTINCT portal_id, participants_json FROM cloud_chat WHERE login_id=$1 AND portal_id <> '' AND deleted=FALSE`,
 		s.loginID,
@@ -2031,7 +2031,7 @@ func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, no
 				normalized = append(normalized, n)
 			}
 		}
-		if participantSetsMatch(normalized, normalizedTarget) {
+		if participantSetsMatch(normalized, normalizedTarget, selfHandle) {
 			matches = append(matches, portalID)
 			seen[portalID] = true
 		}
@@ -2040,9 +2040,10 @@ func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, no
 }
 
 // participantSetsMatch checks if two normalized participant sets are equivalent
-// (same members, ignoring order). Allows ±1 member difference to handle cases
-// where self is included in one set but not the other.
-func participantSetsMatch(a, b []string) bool {
+// (same members, ignoring order). Allows a difference of exactly 1 only if the
+// single differing member is selfHandle (self may be in one set but not the other).
+// Pass an empty selfHandle to disallow any difference.
+func participantSetsMatch(a, b []string, selfHandle string) bool {
 	if len(a) == 0 || len(b) == 0 {
 		return false
 	}
@@ -2054,20 +2055,27 @@ func participantSetsMatch(a, b []string) bool {
 	for _, p := range b {
 		setB[p] = true
 	}
-	// Count members in A not in B, and vice versa.
+	// Count members in A not in B, and vice versa; track the differing member.
+	normalizedSelf := normalizeIdentifierForPortalID(selfHandle)
 	diff := 0
+	var diffMember string
 	for p := range setA {
 		if !setB[p] {
 			diff++
+			diffMember = p
 		}
 	}
 	for p := range setB {
 		if !setA[p] {
 			diff++
+			diffMember = p
 		}
 	}
-	// Allow ±1 difference (self may be in one set but not the other).
-	return diff <= 1
+	if diff == 0 {
+		return true
+	}
+	// Allow exactly 1 difference only when that member is self.
+	return diff == 1 && normalizedSelf != "" && diffMember == normalizedSelf
 }
 
 // deleteLocalChatByGroupID removes all local cloud_chat and cloud_message records

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -2055,26 +2055,27 @@ func participantSetsMatch(a, b []string, isSelf func(string) bool) bool {
 	for _, p := range b {
 		setB[p] = true
 	}
-	// Count members in A not in B, and vice versa; track the differing member.
+	// Count members in A not in B, and vice versa; track whether ALL
+	// differing members are self handles.
+	allDiffAreSelf := true
 	diff := 0
-	var diffMember string
 	for p := range setA {
 		if !setB[p] {
 			diff++
-			diffMember = p
+			if isSelf == nil || !isSelf(p) {
+				allDiffAreSelf = false
+			}
 		}
 	}
 	for p := range setB {
 		if !setA[p] {
 			diff++
-			diffMember = p
+			if isSelf == nil || !isSelf(p) {
+				allDiffAreSelf = false
+			}
 		}
 	}
-	if diff == 0 {
-		return true
-	}
-	// Allow exactly 1 difference only when that member is self.
-	return diff == 1 && isSelf != nil && isSelf(diffMember)
+	return diff == 0 || (allDiffAreSelf && isSelf != nil)
 }
 
 // deleteLocalChatByGroupID removes all local cloud_chat and cloud_message records

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -1993,7 +1993,7 @@ func (s *cloudBackfillStore) portalHasPreStartupOutgoingMessages(ctx context.Con
 // whose participants overlap with the given normalized participant list.
 // Used to find duplicate group portals that have the same members but different
 // group UUIDs. Participants are compared after normalization (tel:/mailto: prefix).
-func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, normalizedTarget []string, selfHandle string) ([]string, error) {
+func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, normalizedTarget []string, isSelf func(string) bool) ([]string, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT DISTINCT portal_id, participants_json FROM cloud_chat WHERE login_id=$1 AND portal_id <> '' AND deleted=FALSE`,
 		s.loginID,
@@ -2031,7 +2031,7 @@ func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, no
 				normalized = append(normalized, n)
 			}
 		}
-		if participantSetsMatch(normalized, normalizedTarget, selfHandle) {
+		if participantSetsMatch(normalized, normalizedTarget, isSelf) {
 			matches = append(matches, portalID)
 			seen[portalID] = true
 		}
@@ -2041,9 +2041,9 @@ func (s *cloudBackfillStore) findPortalIDsByParticipants(ctx context.Context, no
 
 // participantSetsMatch checks if two normalized participant sets are equivalent
 // (same members, ignoring order). Allows a difference of exactly 1 only if the
-// single differing member is selfHandle (self may be in one set but not the other).
-// Pass an empty selfHandle to disallow any difference.
-func participantSetsMatch(a, b []string, selfHandle string) bool {
+// single differing member is self (checked via isSelf predicate, which should
+// test against all known user handles). Pass nil isSelf to disallow any difference.
+func participantSetsMatch(a, b []string, isSelf func(string) bool) bool {
 	if len(a) == 0 || len(b) == 0 {
 		return false
 	}
@@ -2056,7 +2056,6 @@ func participantSetsMatch(a, b []string, selfHandle string) bool {
 		setB[p] = true
 	}
 	// Count members in A not in B, and vice versa; track the differing member.
-	normalizedSelf := normalizeIdentifierForPortalID(selfHandle)
 	diff := 0
 	var diffMember string
 	for p := range setA {
@@ -2075,7 +2074,7 @@ func participantSetsMatch(a, b []string, selfHandle string) bool {
 		return true
 	}
 	// Allow exactly 1 difference only when that member is self.
-	return diff == 1 && normalizedSelf != "" && diffMember == normalizedSelf
+	return diff == 1 && isSelf != nil && isSelf(diffMember)
 }
 
 // deleteLocalChatByGroupID removes all local cloud_chat and cloud_message records

--- a/pkg/connector/cloud_backfill_store_test.go
+++ b/pkg/connector/cloud_backfill_store_test.go
@@ -88,6 +88,13 @@ func TestParticipantSetsMatch(t *testing.T) {
 			want:   false,
 		},
 		{
+			name:   "both diffs are self handles (phone vs email)",
+			a:      []string{"tel:+15551111111", self},
+			b:      []string{"tel:+15551111111", selfEmail},
+			isSelf: isSelf,
+			want:   true,
+		},
+		{
 			name:   "duplicates in input",
 			a:      []string{"tel:+15551111111", "tel:+15551111111"},
 			b:      []string{"tel:+15551111111"},

--- a/pkg/connector/cloud_backfill_store_test.go
+++ b/pkg/connector/cloud_backfill_store_test.go
@@ -4,91 +4,104 @@ import "testing"
 
 func TestParticipantSetsMatch(t *testing.T) {
 	self := "tel:+15551234567"
+	selfEmail := "mailto:user@example.com"
+	// isSelf checks against all known handles (phone + email).
+	isSelf := func(h string) bool {
+		n := normalizeIdentifierForPortalID(h)
+		return n == normalizeIdentifierForPortalID(self) || n == normalizeIdentifierForPortalID(selfEmail)
+	}
 
 	tests := []struct {
-		name       string
-		a, b       []string
-		selfHandle string
-		want       bool
+		name   string
+		a, b   []string
+		isSelf func(string) bool
+		want   bool
 	}{
 		{
-			name:       "identical sets",
-			a:          []string{"tel:+15551111111", "tel:+15552222222", self},
-			b:          []string{"tel:+15552222222", "tel:+15551111111", self},
-			selfHandle: self,
-			want:       true,
+			name:   "identical sets",
+			a:      []string{"tel:+15551111111", "tel:+15552222222", self},
+			b:      []string{"tel:+15552222222", "tel:+15551111111", self},
+			isSelf: isSelf,
+			want:   true,
 		},
 		{
-			name:       "self in a but not b",
-			a:          []string{"tel:+15551111111", self},
-			b:          []string{"tel:+15551111111"},
-			selfHandle: self,
-			want:       true,
+			name:   "self in a but not b",
+			a:      []string{"tel:+15551111111", self},
+			b:      []string{"tel:+15551111111"},
+			isSelf: isSelf,
+			want:   true,
 		},
 		{
-			name:       "self in b but not a",
-			a:          []string{"tel:+15551111111"},
-			b:          []string{"tel:+15551111111", self},
-			selfHandle: self,
-			want:       true,
+			name:   "self in b but not a",
+			a:      []string{"tel:+15551111111"},
+			b:      []string{"tel:+15551111111", self},
+			isSelf: isSelf,
+			want:   true,
 		},
 		{
-			name:       "non-self member differs",
-			a:          []string{"tel:+15551111111", "tel:+15552222222"},
-			b:          []string{"tel:+15551111111", "tel:+15553333333"},
-			selfHandle: self,
-			want:       false,
+			name:   "self email handle in a, phone handle absent",
+			a:      []string{"tel:+15551111111", selfEmail},
+			b:      []string{"tel:+15551111111"},
+			isSelf: isSelf,
+			want:   true,
 		},
 		{
-			name:       "diff is 1 but differing member is not self",
-			a:          []string{"tel:+15551111111", "tel:+15552222222", "tel:+15554444444"},
-			b:          []string{"tel:+15551111111", "tel:+15552222222"},
-			selfHandle: self,
-			want:       false,
+			name:   "non-self member differs",
+			a:      []string{"tel:+15551111111", "tel:+15552222222"},
+			b:      []string{"tel:+15551111111", "tel:+15553333333"},
+			isSelf: isSelf,
+			want:   false,
 		},
 		{
-			name:       "both empty",
-			a:          []string{},
-			b:          []string{},
-			selfHandle: self,
-			want:       false,
+			name:   "diff is 1 but differing member is not self",
+			a:      []string{"tel:+15551111111", "tel:+15552222222", "tel:+15554444444"},
+			b:      []string{"tel:+15551111111", "tel:+15552222222"},
+			isSelf: isSelf,
+			want:   false,
 		},
 		{
-			name:       "empty set a",
-			a:          []string{},
-			b:          []string{"tel:+15551111111"},
-			selfHandle: self,
-			want:       false,
+			name:   "both empty",
+			a:      []string{},
+			b:      []string{},
+			isSelf: isSelf,
+			want:   false,
 		},
 		{
-			name:       "empty set b",
-			a:          []string{"tel:+15551111111"},
-			b:          []string{},
-			selfHandle: self,
-			want:       false,
+			name:   "empty set a",
+			a:      []string{},
+			b:      []string{"tel:+15551111111"},
+			isSelf: isSelf,
+			want:   false,
 		},
 		{
-			name:       "empty selfHandle disallows any difference",
-			a:          []string{"tel:+15551111111", self},
-			b:          []string{"tel:+15551111111"},
-			selfHandle: "",
-			want:       false,
+			name:   "empty set b",
+			a:      []string{"tel:+15551111111"},
+			b:      []string{},
+			isSelf: isSelf,
+			want:   false,
 		},
 		{
-			name:       "duplicates in input",
-			a:          []string{"tel:+15551111111", "tel:+15551111111"},
-			b:          []string{"tel:+15551111111"},
-			selfHandle: self,
-			want:       true,
+			name:   "nil isSelf disallows any difference",
+			a:      []string{"tel:+15551111111", self},
+			b:      []string{"tel:+15551111111"},
+			isSelf: nil,
+			want:   false,
+		},
+		{
+			name:   "duplicates in input",
+			a:      []string{"tel:+15551111111", "tel:+15551111111"},
+			b:      []string{"tel:+15551111111"},
+			isSelf: isSelf,
+			want:   true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := participantSetsMatch(tt.a, tt.b, tt.selfHandle)
+			got := participantSetsMatch(tt.a, tt.b, tt.isSelf)
 			if got != tt.want {
-				t.Errorf("participantSetsMatch(%v, %v, %q) = %v, want %v",
-					tt.a, tt.b, tt.selfHandle, got, tt.want)
+				t.Errorf("participantSetsMatch(%v, %v) = %v, want %v",
+					tt.a, tt.b, got, tt.want)
 			}
 		})
 	}

--- a/pkg/connector/cloud_backfill_store_test.go
+++ b/pkg/connector/cloud_backfill_store_test.go
@@ -1,0 +1,95 @@
+package connector
+
+import "testing"
+
+func TestParticipantSetsMatch(t *testing.T) {
+	self := "tel:+15551234567"
+
+	tests := []struct {
+		name       string
+		a, b       []string
+		selfHandle string
+		want       bool
+	}{
+		{
+			name:       "identical sets",
+			a:          []string{"tel:+15551111111", "tel:+15552222222", self},
+			b:          []string{"tel:+15552222222", "tel:+15551111111", self},
+			selfHandle: self,
+			want:       true,
+		},
+		{
+			name:       "self in a but not b",
+			a:          []string{"tel:+15551111111", self},
+			b:          []string{"tel:+15551111111"},
+			selfHandle: self,
+			want:       true,
+		},
+		{
+			name:       "self in b but not a",
+			a:          []string{"tel:+15551111111"},
+			b:          []string{"tel:+15551111111", self},
+			selfHandle: self,
+			want:       true,
+		},
+		{
+			name:       "non-self member differs",
+			a:          []string{"tel:+15551111111", "tel:+15552222222"},
+			b:          []string{"tel:+15551111111", "tel:+15553333333"},
+			selfHandle: self,
+			want:       false,
+		},
+		{
+			name:       "diff is 1 but differing member is not self",
+			a:          []string{"tel:+15551111111", "tel:+15552222222", "tel:+15554444444"},
+			b:          []string{"tel:+15551111111", "tel:+15552222222"},
+			selfHandle: self,
+			want:       false,
+		},
+		{
+			name:       "both empty",
+			a:          []string{},
+			b:          []string{},
+			selfHandle: self,
+			want:       false,
+		},
+		{
+			name:       "empty set a",
+			a:          []string{},
+			b:          []string{"tel:+15551111111"},
+			selfHandle: self,
+			want:       false,
+		},
+		{
+			name:       "empty set b",
+			a:          []string{"tel:+15551111111"},
+			b:          []string{},
+			selfHandle: self,
+			want:       false,
+		},
+		{
+			name:       "empty selfHandle disallows any difference",
+			a:          []string{"tel:+15551111111", self},
+			b:          []string{"tel:+15551111111"},
+			selfHandle: "",
+			want:       false,
+		},
+		{
+			name:       "duplicates in input",
+			a:          []string{"tel:+15551111111", "tel:+15551111111"},
+			b:          []string{"tel:+15551111111"},
+			selfHandle: self,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := participantSetsMatch(tt.a, tt.b, tt.selfHandle)
+			if got != tt.want {
+				t.Errorf("participantSetsMatch(%v, %v, %q) = %v, want %v",
+					tt.a, tt.b, tt.selfHandle, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -591,7 +591,7 @@ func friendlyPortalName(ctx context.Context, bridge *bridgev2.Bridge, client *IM
 	// For group chats, resolve from cloud store (display_name / contact names).
 	isGroup := strings.HasPrefix(portalID, "gid:") || strings.Contains(portalID, ",")
 	if isGroup && client != nil {
-		if name, _ := client.resolveGroupName(ctx, portalID); name != "" && name != "Group Chat" {
+		if name := client.resolveGroupName(ctx, portalID); name != "" && name != "Group Chat" {
 			return name
 		}
 	}

--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -591,7 +591,7 @@ func friendlyPortalName(ctx context.Context, bridge *bridgev2.Bridge, client *IM
 	// For group chats, resolve from cloud store (display_name / contact names).
 	isGroup := strings.HasPrefix(portalID, "gid:") || strings.Contains(portalID, ",")
 	if isGroup && client != nil {
-		if name := client.resolveGroupName(ctx, portalID); name != "" && name != "Group Chat" {
+		if name, _ := client.resolveGroupName(ctx, portalID); name != "" && name != "Group Chat" {
 			return name
 		}
 	}

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -821,20 +821,8 @@ func (c *IMClient) refreshGroupPortalNamesFromContacts(log zerolog.Logger) {
 		}
 		total++
 
-		newName, authoritative := c.resolveGroupName(ctx, portalID)
+		newName, _ := c.resolveGroupName(ctx, portalID)
 		if newName == "" || newName == portal.Name {
-			continue
-		}
-
-		// Don't overwrite an existing custom name (e.g. "The Fam") with a
-		// participant-generated fallback. Real name changes arrive via
-		// handleRename / APNs envelope and update imGroupNames directly.
-		if portal.Name != "" && !authoritative {
-			log.Debug().
-				Str("portal_id", portalID).
-				Str("current_name", portal.Name).
-				Str("fallback_name", newName).
-				Msg("Skipping fallback rename for portal with existing name")
 			continue
 		}
 

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -821,7 +821,7 @@ func (c *IMClient) refreshGroupPortalNamesFromContacts(log zerolog.Logger) {
 		}
 		total++
 
-		newName, _ := c.resolveGroupName(ctx, portalID)
+		newName := c.resolveGroupName(ctx, portalID)
 		if newName == "" || newName == portal.Name {
 			continue
 		}

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -821,8 +821,14 @@ func (c *IMClient) refreshGroupPortalNamesFromContacts(log zerolog.Logger) {
 		}
 		total++
 
-		newName := c.resolveGroupName(ctx, portalID)
+		newName, authoritative := c.resolveGroupName(ctx, portalID)
 		if newName == "" || newName == portal.Name {
+			continue
+		}
+		// Don't overwrite an existing portal name with a contact-derived
+		// fallback — only authoritative sources (user-set iMessage group
+		// names from the in-memory cache or CloudKit) should rename.
+		if !authoritative && portal.Name != "" {
 			continue
 		}
 

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -821,8 +821,20 @@ func (c *IMClient) refreshGroupPortalNamesFromContacts(log zerolog.Logger) {
 		}
 		total++
 
-		newName := c.resolveGroupName(ctx, portalID)
+		newName, authoritative := c.resolveGroupName(ctx, portalID)
 		if newName == "" || newName == portal.Name {
+			continue
+		}
+
+		// Don't overwrite an existing custom name (e.g. "The Fam") with a
+		// participant-generated fallback. Real name changes arrive via
+		// handleRename / APNs envelope and update imGroupNames directly.
+		if portal.Name != "" && !authoritative {
+			log.Debug().
+				Str("portal_id", portalID).
+				Str("current_name", portal.Name).
+				Str("fallback_name", newName).
+				Msg("Skipping fallback rename for portal with existing name")
 			continue
 		}
 


### PR DESCRIPTION
## Title
fix(groups): preserve authoritative names and stable gid aliases

## Summary
This fixes two related group-portal problems: custom group names being clobbered on restart, and gid alias / participant matching drifting onto the wrong portal.

## Changes
- treat CloudKit / cached group names as authoritative and avoid participant-fallback renames for existing rooms
- tighten participant-set matching so diff=1 only passes for self-only differences
- harden gid alias eviction and stale-cache self-healing
- fold the participant-list helper refactor into the final behavior change for a smaller PR surface

## Notes
- Scope is the shared group portal logic; no chat.db-only fixes are included here.
