### PR TITLE
fix(connector): target replies and tapbacks to the correct part

### DIFF
--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -110,6 +110,18 @@ func (db *chatDB) findGroupChatGUID(portalID string, c *IMClient) string {
 	return ""
 }
 
+// chatDBReplyTarget returns the correct MessageOptionalPartID for a reply,
+// mapping chat.db balloon-part index to the emitted part IDs:
+// bp<=0 -> base GUID (text body); bp>=1 -> {guid}_att{bp-1} (attachment).
+// Negative part values are normalized to 0 (base-message semantics).
+func chatDBReplyTarget(replyGUID string, replyPart int) *networkid.MessageOptionalPartID {
+	targetID := replyGUID
+	if replyPart >= 1 {
+		targetID = fmt.Sprintf("%s_att%d", replyGUID, replyPart-1)
+	}
+	return &networkid.MessageOptionalPartID{MessageID: makeMessageID(targetID)}
+}
+
 // FetchMessages retrieves historical messages from chat.db for backfill.
 func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessagesParams, c *IMClient) (*bridgev2.FetchMessagesResponse, error) {
 	portalID := string(params.Portal.ID)
@@ -223,6 +235,9 @@ func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessag
 				continue
 			}
 			partID := fmt.Sprintf("%s_att%d", msg.GUID, i)
+			if msg.ReplyToGUID != "" {
+				attCm.ReplyTo = chatDBReplyTarget(msg.ReplyToGUID, msg.ReplyToPart)
+			}
 			backfillMessages = append(backfillMessages, &bridgev2.BackfillMessage{
 				ConvertedMessage: attCm,
 				Sender:           sender,
@@ -345,12 +360,16 @@ func convertChatDBMessage(ctx context.Context, portal *bridgev2.Portal, intent b
 		}
 	}
 
-	return &bridgev2.ConvertedMessage{
+	cm := &bridgev2.ConvertedMessage{
 		Parts: []*bridgev2.ConvertedMessagePart{{
 			Type:    event.EventMessage,
 			Content: content,
 		}},
-	}, nil
+	}
+	if msg.ReplyToGUID != "" {
+		cm.ReplyTo = chatDBReplyTarget(msg.ReplyToGUID, msg.ReplyToPart)
+	}
+	return cm, nil
 }
 
 func convertChatDBAttachment(ctx context.Context, portal *bridgev2.Portal, intent bridgev2.MatrixAPI, msg *imessage.Message, att *imessage.Attachment, videoTranscoding, heicConversion bool, heicQuality int) (*bridgev2.ConvertedMessage, error) {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4931,9 +4931,11 @@ func (c *IMClient) cloudRowsToBackfillMessages(ctx context.Context, rows []cloud
 		tapbackType := *row.TapbackType
 		isRemove := tapbackType >= 3000
 
-		// Parse target GUID from "p:0/GUID" format.
+		// Parse target GUID and balloon-part index from "p:N/GUID" format.
 		targetGUID := row.TapbackTargetGUID
+		bp := 0
 		if parts := strings.SplitN(targetGUID, "/", 2); len(parts) == 2 {
+			fmt.Sscanf(parts[0], "p:%d", &bp)
 			targetGUID = parts[1]
 		}
 		if targetGUID == "" {
@@ -4947,10 +4949,19 @@ func (c *IMClient) cloudRowsToBackfillMessages(ctx context.Context, rows []cloud
 			ts := time.UnixMilli(row.TimestampMS)
 			idx := tapbackType - 2000
 			emoji := tapbackTypeToEmoji(&idx, &row.TapbackEmoji)
+			// Map balloon-part index to bridge part ID:
+			// bp 0 = text body (nil TargetPart → first part),
+			// bp >= 1 = attachment (att0, att1, …).
+			var targetPart *networkid.PartID
+			if bp >= 1 {
+				p := networkid.PartID(fmt.Sprintf("att%d", bp-1))
+				targetPart = &p
+			}
 			targetMsg.Reactions = append(targetMsg.Reactions, &bridgev2.BackfillReaction{
-				Sender:    sender,
-				Emoji:     emoji,
-				Timestamp: ts,
+				Sender:     sender,
+				Emoji:      emoji,
+				Timestamp:  ts,
+				TargetPart: targetPart,
 			})
 		} else {
 			// Fall back to QueueRemoteEvent for removes and out-of-batch targets.

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1445,8 +1445,13 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 			Sender:    c.canonicalizeDMSender(portalKey, c.makeEventSender(msg.Sender)),
 			Timestamp: time.UnixMilli(int64(msg.TimestampMs)),
 		},
-		TargetMessage: makeMessageID(targetGUID),
-		Emoji:         emoji,
+		TargetMessage: makeMessageID(func() string {
+			if msg.TapbackTargetPart != nil && *msg.TapbackTargetPart >= 1 {
+				return fmt.Sprintf("%s_att%d", targetGUID, *msg.TapbackTargetPart-1)
+			}
+			return targetGUID
+		}()),
+		Emoji: emoji,
 	})
 }
 
@@ -3783,7 +3788,8 @@ func (c *IMClient) HandleMatrixReaction(ctx context.Context, msg *bridgev2.Matri
 		return nil, nil
 	}
 
-	_, err := c.client.SendTapback(conv, string(msg.TargetMessage.ID), 0, reaction, emoji, false, c.handle)
+	targetUUID, targetPart := extractTapbackTarget(string(msg.TargetMessage.ID))
+	_, err := c.client.SendTapback(conv, targetUUID, targetPart, reaction, emoji, false, c.handle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send tapback: %w", err)
 	}
@@ -3823,7 +3829,8 @@ func (c *IMClient) HandleMatrixReactionRemove(ctx context.Context, msg *bridgev2
 		return nil
 	}
 
-	_, err := c.client.SendTapback(conv, string(msg.TargetReaction.MessageID), 0, reaction, emoji, true, c.handle)
+	targetUUID, targetPart := extractTapbackTarget(string(msg.TargetReaction.MessageID))
+	_, err := c.client.SendTapback(conv, targetUUID, targetPart, reaction, emoji, true, c.handle)
 	return err
 }
 
@@ -5085,13 +5092,19 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 	}
 	emoji := tapbackTypeToEmoji(&idx, &row.TapbackEmoji)
 
-	// Parse target GUID from "p:0/GUID" format
+	// Parse target GUID from "p:N/GUID" format, preserving the part index.
 	targetGUID := row.TapbackTargetGUID
+	bp := 0
 	if parts := strings.SplitN(targetGUID, "/", 2); len(parts) == 2 {
+		fmt.Sscanf(parts[0], "p:%d", &bp)
 		targetGUID = parts[1]
 	}
 	if targetGUID == "" {
 		return nil
+	}
+	targetID := targetGUID
+	if bp >= 1 {
+		targetID = fmt.Sprintf("%s_att%d", targetGUID, bp-1)
 	}
 
 	evtType := bridgev2.RemoteEventReaction
@@ -5107,7 +5120,7 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 	// for minutes. Checking the reaction table here is a cheap PK lookup that
 	// prevents the queue from filling with known duplicates.
 	if !isRemove {
-		targetMsgID := makeMessageID(targetGUID)
+		targetMsgID := makeMessageID(targetID)
 		existing, err := c.Main.Bridge.DB.Reaction.GetByIDWithoutMessagePart(
 			context.Background(), c.UserLogin.ID, targetMsgID, sender.Sender, "",
 		)
@@ -5129,7 +5142,7 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 			Sender:    sender,
 			Timestamp: ts,
 		},
-		TargetMessage: makeMessageID(targetGUID),
+		TargetMessage: makeMessageID(targetID),
 		Emoji:         emoji,
 	})
 	return nil
@@ -7301,8 +7314,11 @@ func convertMessage(ctx context.Context, portal *bridgev2.Portal, intent bridgev
 	}
 
 	if msg.ReplyGuid != nil && *msg.ReplyGuid != "" {
-		replyToID := makeMessageID(*msg.ReplyGuid)
-		cm.ReplyTo = &networkid.MessageOptionalPartID{MessageID: replyToID}
+		bp := 0
+		if msg.ReplyPart != nil {
+			fmt.Sscanf(*msg.ReplyPart, "%d:", &bp)
+		}
+		cm.ReplyTo = chatDBReplyTarget(*msg.ReplyGuid, bp)
 	}
 
 	return cm, nil
@@ -7475,8 +7491,11 @@ func convertAttachment(ctx context.Context, portal *bridgev2.Portal, intent brid
 	}
 
 	if attMsg.WrappedMessage.ReplyGuid != nil && *attMsg.WrappedMessage.ReplyGuid != "" {
-		replyToID := makeMessageID(*attMsg.WrappedMessage.ReplyGuid)
-		cm.ReplyTo = &networkid.MessageOptionalPartID{MessageID: replyToID}
+		bp := 0
+		if attMsg.WrappedMessage.ReplyPart != nil {
+			fmt.Sscanf(*attMsg.WrappedMessage.ReplyPart, "%d:", &bp)
+		}
+		cm.ReplyTo = chatDBReplyTarget(*attMsg.WrappedMessage.ReplyGuid, bp)
 	}
 
 	return cm, nil
@@ -7485,6 +7504,18 @@ func convertAttachment(ctx context.Context, portal *bridgev2.Portal, intent brid
 // ============================================================================
 // Static helpers
 // ============================================================================
+
+// extractTapbackTarget splits a message ID that may contain an _attN suffix into
+// the bare UUID and the iMessage tapback part index (0 = text body, ≥1 = attachment).
+// The _attN index is 0-based (att0 = first attachment = part 1 in iMessage).
+func extractTapbackTarget(messageID string) (string, uint64) {
+	if idx := strings.Index(messageID, "_att"); idx > 0 {
+		var attIndex uint64
+		fmt.Sscanf(messageID[idx+4:], "%d", &attIndex)
+		return messageID[:idx], attIndex + 1
+	}
+	return messageID, 0
+}
 
 // extractReplyInfo converts a bridgev2 reply-to database message into the
 // iMessage reply_guid and reply_part strings expected by rustpush.
@@ -7495,16 +7526,20 @@ func extractReplyInfo(replyTo *database.Message) (*string, *string) {
 		return nil, nil
 	}
 	guid := string(replyTo.ID)
-	// Strip attachment suffixes like _att0, _att1 — iMessage expects a pure UUID
+	// Strip attachment suffixes like _att0, _att1 — iMessage expects a pure UUID,
+	// but we derive the balloon-part index from the suffix to set reply_part correctly.
+	bp := 0
 	if idx := strings.Index(guid, "_att"); idx > 0 {
+		fmt.Sscanf(guid[idx+4:], "%d", &bp)
+		bp++
 		guid = guid[:idx]
 	}
 	// iMessage thread_originator_part format is "bp:type:length" where:
-	//   bp = balloon part index (0 for normal messages)
+	//   bp = balloon part index (0 for text body, ≥1 for attachments)
 	//   type = part type (0 for text)
 	//   length = character count of the original message text
 	// We use 0 as the length since we don't have the original text available.
-	part := "0:0:0"
+	part := fmt.Sprintf("%d:0:0", bp)
 	return &guid, &part
 }
 

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1438,10 +1438,11 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 		evtType = bridgev2.RemoteEventReactionRemove
 	}
 
-	tapbackTargetID := targetGUID
-	if msg.TapbackTargetPart != nil && *msg.TapbackTargetPart >= 1 {
-		tapbackTargetID = fmt.Sprintf("%s_att%d", targetGUID, *msg.TapbackTargetPart-1)
+	tapbackPart := 0
+	if msg.TapbackTargetPart != nil {
+		tapbackPart = int(*msg.TapbackTargetPart)
 	}
+	tapbackTargetMsgID := c.resolveTapbackTargetID(targetGUID, tapbackPart)
 
 	c.Main.Bridge.QueueRemoteEvent(c.UserLogin, &simplevent.Reaction{
 		EventMeta: simplevent.EventMeta{
@@ -1450,7 +1451,7 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 			Sender:    c.canonicalizeDMSender(portalKey, c.makeEventSender(msg.Sender)),
 			Timestamp: time.UnixMilli(int64(msg.TimestampMs)),
 		},
-		TargetMessage: makeMessageID(tapbackTargetID),
+		TargetMessage: tapbackTargetMsgID,
 		Emoji:         emoji,
 	})
 }
@@ -5106,10 +5107,7 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 	if targetGUID == "" {
 		return nil
 	}
-	targetID := targetGUID
-	if bp >= 1 {
-		targetID = fmt.Sprintf("%s_att%d", targetGUID, bp-1)
-	}
+	targetMsgID := c.resolveTapbackTargetID(targetGUID, bp)
 
 	evtType := bridgev2.RemoteEventReaction
 	if isRemove {
@@ -5124,7 +5122,6 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 	// for minutes. Checking the reaction table here is a cheap PK lookup that
 	// prevents the queue from filling with known duplicates.
 	if !isRemove {
-		targetMsgID := makeMessageID(targetID)
 		existing, err := c.Main.Bridge.DB.Reaction.GetByIDWithoutMessagePart(
 			context.Background(), c.UserLogin.ID, targetMsgID, sender.Sender, "",
 		)
@@ -5146,7 +5143,7 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 			Sender:    sender,
 			Timestamp: ts,
 		},
-		TargetMessage: makeMessageID(targetID),
+		TargetMessage: targetMsgID,
 		Emoji:         emoji,
 	})
 	return nil
@@ -7503,6 +7500,26 @@ func convertAttachment(ctx context.Context, portal *bridgev2.Portal, intent brid
 	}
 
 	return cm, nil
+}
+
+// resolveTapbackTargetID constructs the message ID for a tapback target,
+// handling backward compatibility with messages stored before part-targeting
+// was introduced. For bp >= 1 it tries the suffixed ID (e.g. "uuid_att0")
+// first; if that message doesn't exist in the bridge DB it falls back to the
+// bare UUID, which is how pre-existing messages were stored.
+func (c *IMClient) resolveTapbackTargetID(targetGUID string, bp int) networkid.MessageID {
+	if bp >= 1 {
+		suffixed := fmt.Sprintf("%s_att%d", targetGUID, bp-1)
+		suffixedID := makeMessageID(suffixed)
+		msg, err := c.Main.Bridge.DB.Message.GetFirstPartByID(
+			context.Background(), c.UserLogin.ID, suffixedID,
+		)
+		if err == nil && msg != nil {
+			return suffixedID
+		}
+		// Suffixed ID not found — fall back to bare UUID for old messages.
+	}
+	return makeMessageID(targetGUID)
 }
 
 // ============================================================================

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1438,6 +1438,11 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 		evtType = bridgev2.RemoteEventReactionRemove
 	}
 
+	tapbackTargetID := targetGUID
+	if msg.TapbackTargetPart != nil && *msg.TapbackTargetPart >= 1 {
+		tapbackTargetID = fmt.Sprintf("%s_att%d", targetGUID, *msg.TapbackTargetPart-1)
+	}
+
 	c.Main.Bridge.QueueRemoteEvent(c.UserLogin, &simplevent.Reaction{
 		EventMeta: simplevent.EventMeta{
 			Type:      evtType,
@@ -1445,13 +1450,8 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 			Sender:    c.canonicalizeDMSender(portalKey, c.makeEventSender(msg.Sender)),
 			Timestamp: time.UnixMilli(int64(msg.TimestampMs)),
 		},
-		TargetMessage: makeMessageID(func() string {
-			if msg.TapbackTargetPart != nil && *msg.TapbackTargetPart >= 1 {
-				return fmt.Sprintf("%s_att%d", targetGUID, *msg.TapbackTargetPart-1)
-			}
-			return targetGUID
-		}()),
-		Emoji: emoji,
+		TargetMessage: makeMessageID(tapbackTargetID),
+		Emoji:         emoji,
 	})
 }
 

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -3769,7 +3769,9 @@ func (c *IMClient) HandleMatrixReaction(ctx context.Context, msg *bridgev2.Matri
 		// Sending via SendMessage() with the reaction text uses RawSmsOutgoingMessage
 		// format, which the iPhone routes by participants without needing a stable
 		// sender_guid, correctly delivering to the existing SMS/RCS thread.
-		targetGUID := string(msg.TargetMessage.ID)
+		// Strip _attN suffix: SMS doesn't support part-targeting, and the
+		// suffixed ID would fail lookups and relay routing.
+		targetGUID, _ := extractTapbackTarget(string(msg.TargetMessage.ID))
 		reactionText := formatSMSReactionText(reaction, emoji, false)
 		if c.cloudStore != nil {
 			if origText, err := c.cloudStore.getMessageTextByGUID(ctx, targetGUID); err == nil && origText != "" {
@@ -3814,7 +3816,9 @@ func (c *IMClient) HandleMatrixReactionRemove(ctx context.Context, msg *bridgev2
 	if conv.IsSms {
 		// Same SMS routing fix as HandleMatrixReaction: use SendMessage instead
 		// of SendTapback to avoid the phantom new-thread creation.
-		targetGUID := string(msg.TargetReaction.MessageID)
+		// Strip _attN suffix: SMS doesn't support part-targeting, and the
+		// suffixed ID would fail lookups and relay routing.
+		targetGUID, _ := extractTapbackTarget(string(msg.TargetReaction.MessageID))
 		reactionText := formatSMSReactionText(reaction, emoji, true)
 		if c.cloudStore != nil {
 			if origText, err := c.cloudStore.getMessageTextByGUID(ctx, targetGUID); err == nil && origText != "" {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -4935,7 +4935,7 @@ func (c *IMClient) cloudRowsToBackfillMessages(ctx context.Context, rows []cloud
 		targetGUID := row.TapbackTargetGUID
 		bp := 0
 		if parts := strings.SplitN(targetGUID, "/", 2); len(parts) == 2 {
-			fmt.Sscanf(parts[0], "p:%d", &bp)
+			bp = parseBalloonPart(parts[0], "p:%d")
 			targetGUID = parts[1]
 		}
 		if targetGUID == "" {
@@ -5112,7 +5112,7 @@ func (c *IMClient) cloudTapbackToBackfill(row cloudMessageRow, sender bridgev2.E
 	targetGUID := row.TapbackTargetGUID
 	bp := 0
 	if parts := strings.SplitN(targetGUID, "/", 2); len(parts) == 2 {
-		fmt.Sscanf(parts[0], "p:%d", &bp)
+		bp = parseBalloonPart(parts[0], "p:%d")
 		targetGUID = parts[1]
 	}
 	if targetGUID == "" {
@@ -7328,7 +7328,7 @@ func convertMessage(ctx context.Context, portal *bridgev2.Portal, intent bridgev
 	if msg.ReplyGuid != nil && *msg.ReplyGuid != "" {
 		bp := 0
 		if msg.ReplyPart != nil {
-			fmt.Sscanf(*msg.ReplyPart, "%d:", &bp)
+			bp = parseBalloonPart(*msg.ReplyPart, "%d:")
 		}
 		cm.ReplyTo = chatDBReplyTarget(*msg.ReplyGuid, bp)
 	}
@@ -7505,7 +7505,7 @@ func convertAttachment(ctx context.Context, portal *bridgev2.Portal, intent brid
 	if attMsg.WrappedMessage.ReplyGuid != nil && *attMsg.WrappedMessage.ReplyGuid != "" {
 		bp := 0
 		if attMsg.WrappedMessage.ReplyPart != nil {
-			fmt.Sscanf(*attMsg.WrappedMessage.ReplyPart, "%d:", &bp)
+			bp = parseBalloonPart(*attMsg.WrappedMessage.ReplyPart, "%d:")
 		}
 		cm.ReplyTo = chatDBReplyTarget(*attMsg.WrappedMessage.ReplyGuid, bp)
 	}
@@ -7537,14 +7537,21 @@ func (c *IMClient) resolveTapbackTargetID(targetGUID string, bp int) networkid.M
 // Static helpers
 // ============================================================================
 
+// parseBalloonPart extracts an integer balloon-part index from s using the
+// given fmt.Sscanf format string. Returns 0 if s is empty or parsing fails.
+func parseBalloonPart(s, format string) int {
+	var bp int
+	fmt.Sscanf(s, format, &bp)
+	return bp
+}
+
 // extractTapbackTarget splits a message ID that may contain an _attN suffix into
 // the bare UUID and the iMessage tapback part index (0 = text body, ≥1 = attachment).
 // The _attN index is 0-based (att0 = first attachment = part 1 in iMessage).
 func extractTapbackTarget(messageID string) (string, uint64) {
 	if idx := strings.Index(messageID, "_att"); idx > 0 {
-		var attIndex uint64
-		fmt.Sscanf(messageID[idx+4:], "%d", &attIndex)
-		return messageID[:idx], attIndex + 1
+		attIndex := parseBalloonPart(messageID[idx+4:], "%d")
+		return messageID[:idx], uint64(attIndex) + 1
 	}
 	return messageID, 0
 }
@@ -7562,8 +7569,7 @@ func extractReplyInfo(replyTo *database.Message) (*string, *string) {
 	// but we derive the balloon-part index from the suffix to set reply_part correctly.
 	bp := 0
 	if idx := strings.Index(guid, "_att"); idx > 0 {
-		fmt.Sscanf(guid[idx+4:], "%d", &bp)
-		bp++
+		bp = parseBalloonPart(guid[idx+4:], "%d") + 1
 		guid = guid[:idx]
 	}
 	// iMessage thread_originator_part format is "bp:type:length" where:


### PR DESCRIPTION
## Title
fix(connector): target replies and tapbacks to the correct part

## Summary
Replies and tapbacks to attachment parts were landing on the base message instead of the correct `_attN` part. This aligns live, CloudKit backfill, Matrix outbound, and chat.db backfill behavior.

## Changes
- preserve reply/tapback part indices in live handling
- preserve reply/tapback part indices in CloudKit backfill and Matrix outbound
- add the minimal chat.db reply-target helper and `ReplyTo` propagation needed for parity

## Notes
- This intentionally excludes the unrelated group-avatar and gid-member-match hunks from the source commits.
- No Live Photo behavior is changed here.
