### PR TITLE
fix(heic): decode for dimensions/thumbnail when conversion is disabled

### DIFF
--- a/pkg/connector/heic.go
+++ b/pkg/connector/heic.go
@@ -532,6 +532,11 @@ func maybeConvertHEIC(log *zerolog.Logger, data []byte, mimeType, fileName strin
 
 	if !enabled {
 		// Decode for dimensions/thumbnail only, keep original HEIC data
+		if len(data) > maxHEICInputSize {
+			log.Warn().Int("heic_bytes", len(data)).Int("max_bytes", maxHEICInputSize).
+				Msg("HEIC input too large to decode for dimensions, skipping")
+			return data, mimeType, fileName, nil
+		}
 		img, err := decodeHEICImage(data)
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to decode HEIC for dimensions")

--- a/pkg/connector/heic.go
+++ b/pkg/connector/heic.go
@@ -519,14 +519,24 @@ func convertHEICToJPEG(data []byte, mimeType, fileName string, quality int, log 
 	return jpegBytes, "image/jpeg", newName, goImg, nil
 }
 
-// maybeConvertHEIC checks whether HEIC conversion is enabled and the MIME type
-// is HEIC/HEIF. If so, it converts to JPEG and returns the updated data, MIME
-// type, filename, and the decoded image (for dimension/thumbnail extraction
-// without re-decoding). On failure or if conversion is not applicable, it
-// returns the original values unchanged and a nil image.
+// maybeConvertHEIC handles HEIC/HEIF images. When conversion is enabled, it
+// converts to JPEG and returns the updated data, MIME type, filename, and the
+// decoded image. When conversion is disabled but the MIME type is HEIC/HEIF,
+// it decodes the image for dimension/thumbnail extraction while returning the
+// original data unchanged. Returns a nil image only for non-HEIC types or on
+// decode failure.
 func maybeConvertHEIC(log *zerolog.Logger, data []byte, mimeType, fileName string, quality int, enabled bool) ([]byte, string, string, image.Image) {
-	if !enabled || !isHEIC(mimeType) || len(data) == 0 {
+	if !isHEIC(mimeType) || len(data) == 0 {
 		return data, mimeType, fileName, nil
+	}
+
+	if !enabled {
+		// Decode for dimensions/thumbnail only, keep original HEIC data
+		img, err := decodeHEICImage(data)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to decode HEIC for dimensions")
+		}
+		return data, mimeType, fileName, img
 	}
 
 	// Check for animated/multi-frame HEIC


### PR DESCRIPTION
## Title
fix(heic): decode for dimensions/thumbnail when conversion is disabled

## Summary
When `heic_conversion` is disabled, HEIC uploads should still expose dimensions and a thumbnail so Matrix clients can render them inline.

## Changes
- decode HEIC data for metadata and thumbnail extraction even when conversion is off
- keep the original HEIC bytes unchanged

## Notes
- This does not change Live Photo semantics.
