### PR TITLE
carddav: strip spaces from Google app password input

### DIFF
--- a/cmd/mautrix-imessage/carddav_setup.go
+++ b/cmd/mautrix-imessage/carddav_setup.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog"
 
@@ -32,12 +33,20 @@ func runCardDAVSetup() {
 	password := fs.String("password", "", "App password for CardDAV authentication")
 	username := fs.String("username", "", "Username (defaults to email if empty)")
 	url := fs.String("url", "", "CardDAV URL (skip auto-discovery)")
+	stripSpaces := fs.Bool("strip-spaces", false, "Strip spaces from password (for Google app passwords)")
 
 	fs.Parse(os.Args[2:])
 
 	if *email == "" || *password == "" {
-		fmt.Fprintln(os.Stderr, "Usage: carddav-setup --email <email> --password <password> [--username <user>] [--url <url>]")
+		fmt.Fprintln(os.Stderr, "Usage: carddav-setup --email <email> --password <password> [--username <user>] [--url <url>] [--strip-spaces]")
 		os.Exit(1)
+	}
+
+	cleanPassword := *password
+	if *stripSpaces {
+		// Google app passwords are displayed with spaces (e.g. "abcd efgh ijkl mnop").
+		// Strip them so users can paste as-is without auth failures.
+		cleanPassword = strings.ReplaceAll(cleanPassword, " ", "")
 	}
 
 	log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
@@ -51,7 +60,7 @@ func runCardDAVSetup() {
 	discoveredURL := *url
 	if discoveredURL == "" {
 		var err error
-		discoveredURL, err = connector.DiscoverCardDAVURL(*email, effectiveUsername, *password, log)
+		discoveredURL, err = connector.DiscoverCardDAVURL(*email, effectiveUsername, cleanPassword, log)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: CardDAV auto-discovery failed: %v\n", err)
 			os.Exit(1)
@@ -60,7 +69,7 @@ func runCardDAVSetup() {
 	}
 
 	// Encrypt the password
-	encrypted, err := connector.EncryptCardDAVPassword(*password)
+	encrypted, err := connector.EncryptCardDAVPassword(cleanPassword)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Failed to encrypt password: %v\n", err)
 		os.Exit(1)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -400,7 +400,7 @@ open('$CONFIG', 'w').write(text)
             case "$CONTACT_CHOICE" in
                 2)
                     CARDDAV_URL="https://www.googleapis.com/carddav/v1/principals/$CARDDAV_EMAIL/lists/default/"
-                    echo "  Note: Use a Google App Password, without spaces (https://myaccount.google.com/apppasswords)"
+                    echo "  Note: Use a Google App Password (https://myaccount.google.com/apppasswords)"
                     ;;
                 3)
                     CARDDAV_URL="https://carddav.fastmail.com/dav/addressbooks/user/$CARDDAV_EMAIL/Default/"
@@ -430,6 +430,9 @@ open('$CONFIG', 'w').write(text)
 
             # Encrypt password and patch config
             CARDDAV_ARGS="--email $CARDDAV_EMAIL --password $CARDDAV_PASSWORD --url $CARDDAV_URL"
+            if [ "$CONTACT_CHOICE" = "2" ]; then
+                CARDDAV_ARGS="$CARDDAV_ARGS --strip-spaces"
+            fi
             if [ -n "$CARDDAV_USERNAME" ]; then
                 CARDDAV_ARGS="$CARDDAV_ARGS --username $CARDDAV_USERNAME"
             fi


### PR DESCRIPTION
Google app passwords are displayed with spaces (e.g. \`abcd efgh ijkl mnop\`) and users commonly copy-paste them as-is. This causes silent auth failures since the raw password with spaces doesn't match what Google expects.

This strips all spaces from the password before it's used for CardDAV discovery or encryption, making setup forgiving of the natural copy-paste behavior.

The install script prompt is also updated to say spaces are stripped automatically rather than instructing users to remove them manually."