### PR TITLE
Sort shared album assets by DateCreated before slicing latest 50

### DIFF
--- a/pkg/connector/sharedstreams.go
+++ b/pkg/connector/sharedstreams.go
@@ -24,6 +24,7 @@ import (
 	"image/jpeg"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -277,7 +278,20 @@ func handleAlbumSelection(ce *commands.Event, client *IMClient, albums []rustpus
 		return
 	}
 
-	shown := assets
+	// Precompute parsed DateCreated once per asset \u2014 used for sorting and display.
+	type assetWithTime struct {
+		asset rustpushgo.SharedAssetInfo
+		t     time.Time
+	}
+	withTimes := make([]assetWithTime, len(assets))
+	for i, a := range assets {
+		withTimes[i].asset = a
+		withTimes[i].t, _ = time.Parse(time.RFC3339, a.DateCreated)
+	}
+
+	sort.SliceStable(withTimes, func(i, j int) bool { return withTimes[i].t.Before(withTimes[j].t) })
+
+	shown := withTimes
 	truncated := false
 	if len(shown) > 50 {
 		shown = shown[len(shown)-50:]
@@ -291,16 +305,15 @@ func handleAlbumSelection(ce *commands.Event, client *IMClient, albums []rustpus
 	}
 	sb.WriteString("\n\n")
 
-	for i, a := range shown {
+	for i, awt := range shown {
+		a := awt.asset
 		dims := ""
 		if a.Width != "" && a.Height != "" && a.Width != "0" && a.Height != "0" {
 			dims = fmt.Sprintf(", %s\u00d7%s", a.Width, a.Height)
 		}
 		date := ""
-		if a.DateCreated != "" {
-			if t, parseErr := time.Parse(time.RFC3339, a.DateCreated); parseErr == nil {
-				date = fmt.Sprintf(", %s", t.Format("2006-01-02"))
-			}
+		if !awt.t.IsZero() {
+			date = fmt.Sprintf(", %s", awt.t.Format("2006-01-02"))
 		}
 		mediaLabel := a.MediaType
 		if mediaLabel == "" {
@@ -311,10 +324,15 @@ func handleAlbumSelection(ce *commands.Event, client *IMClient, albums []rustpus
 	sb.WriteString("\nReply with number(s), a range (1-5), or `all` to download. `$cmdprefix cancel` to cancel.")
 	ce.Reply(sb.String())
 
+	shownAssets := make([]rustpushgo.SharedAssetInfo, len(shown))
+	for i, awt := range shown {
+		shownAssets[i] = awt.asset
+	}
+
 	commands.StoreCommandState(ce.User, &commands.CommandState{
 		Action: "select shared album assets",
 		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
-			handleAssetSelection(ce, client, ss, albumGUID, albumName, shown)
+			handleAssetSelection(ce, client, ss, albumGUID, albumName, shownAssets)
 		}),
 		Cancel: func() {},
 	})

--- a/pkg/connector/sharedstreams.go
+++ b/pkg/connector/sharedstreams.go
@@ -278,7 +278,6 @@ func handleAlbumSelection(ce *commands.Event, client *IMClient, albums []rustpus
 		return
 	}
 
-	// Precompute parsed DateCreated once per asset \u2014 used for sorting and display.
 	type assetWithTime struct {
 		asset rustpushgo.SharedAssetInfo
 		t     time.Time


### PR DESCRIPTION
## Summary

- `GetAlbumAssets` does not guarantee chronological order, so taking `assets[len-50:]` could return arbitrary items instead of the most recent ones.
- Precompute `time.Parse(DateCreated)` once per asset into a local `assetWithTime` slice, reused for both sort order and display (no redundant parses).
- Sort by `DateCreated` ascending using `sort.SliceStable`, then slice the last 50.

## Behavior change: assets with missing/unparseable DateCreated

Assets with an empty or unparseable `DateCreated` parse to the zero `time.Time` and sort to the front — meaning they are the first to be dropped when truncating to 50. This is almost certainly desirable (prefer dropping undated assets over dated recent ones), but it is a behavior change vs. the previous undefined ordering.

## Test plan

- [ ] Open an album with more than 50 assets
- [ ] Verify the listed 50 assets are the 50 most recently created, ordered oldest→newest (matching the numbered display order)
- [ ] Verify albums with ≤50 assets are unaffected
- [ ] Verify assets with missing/unparseable `DateCreated` appear at the start of the list (and are dropped first when truncating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)