### PR TITLE
[codex] Fix delivered receipts racing message insert

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -2209,7 +2209,18 @@ func (c *IMClient) OnMessage(msg rustpushgo.WrappedMessage) {
 	}
 
 	if msg.IsDelivered {
-		c.handleDeliveryReceipt(log, msg)
+		// Delivery receipts for our own outgoing sends can arrive while the
+		// rustpush send call is still unwinding. Handle them asynchronously so
+		// bridgev2 can commit the outgoing message row before the receipt lookup
+		// retry loop runs.
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("Panic in handleDeliveryReceipt")
+				}
+			}()
+			c.handleDeliveryReceipt(log, msg)
+		}()
 		return
 	}
 


### PR DESCRIPTION
## Summary

Handle incoming iMessage delivery receipts asynchronously instead of inline on the rustpush callback stack.

## Root Cause

Delivery receipts for outgoing sends can arrive while the rustpush send call is still unwinding. The bridge previously handled those receipts inline, so `handleDeliveryReceipt` could query the bridge DB before bridgev2 had committed the outgoing message row. That caused the receipt to be dropped as `target message not in bridge DB`, leaving the Matrix send status at sent instead of delivered.

## Impact

The callback can now return promptly, allowing bridgev2 to insert the outgoing message row before the existing delivery receipt lookup/backoff runs. The change is limited to delivery receipt dispatch; send logic, FFI, schema, and config are unchanged.

## Validation

- `make build`
- `CGO_CFLAGS="-I/opt/homebrew/include" CGO_LDFLAGS="-L/opt/homebrew/lib -L/private/tmp/imessage-pr-delivery" go test ./pkg/connector`