### PR TITLE
Adjust Bridge for Multi-User Environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Git history
+.git/
+
+# Upstream rustpush clone — built dynamically via ensure-rustpush-source
+third_party/rustpush-upstream/
+
+# Rust build artifacts
+pkg/rustpushgo/target/
+librustpushgo.a
+
+# Go build outputs
+mautrix-imessage-v2
+mautrix-imessage
+bbctl
+
+# macOS app bundles
+*.app/
+
+# Runtime / install-generated configs (keep example-config.yaml for go:embed)
+/config.yaml
+/registration.yaml
+state/
+data/
+*.log
+*.db
+*.db-wal
+*.db-shm
+*.session
+
+# Tools not needed for the bridge build
+tools/
+scripts/
+docs/
+dev/
+
+# IDE / editor / misc
+.idea/
+.vscode/
+.DS_Store
+.build-commit
+prompts/
+_todo/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,11 @@ name: Docker
 
 on:
   push:
-    branches: [master]
+    branches: [master, multi-user]
     tags: ["v*"]
   pull_request:
-    branches: [master]
+    branches: [master, multi-user]
+  workflow_dispatch: {}
 
 env:
   IMAGE: ghcr.io/jasonlaguidice/imessage

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,123 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+    branches: [master]
+
+env:
+  IMAGE: ghcr.io/jasonlaguidice/imessage
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute build metadata
+        id: meta
+        run: |
+          echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          # On PRs: load locally for validation only; on push: push by digest
+          push: ${{ github.event_name != 'pull_request' }}
+          outputs: ${{ github.event_name != 'pull_request' && 'type=image,push-by-digest=true,name-canonical=true' || 'type=docker' }}
+          tags: ${{ env.IMAGE }}
+          build-args: |
+            BUILD_VERSION=${{ steps.meta.outputs.version }}
+            BUILD_COMMIT=${{ steps.meta.outputs.commit }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-amd64
+          path: /tmp/digests
+
+      - name: Download arm64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-arm64
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         -out /usr/local/share/ca-certificates/AppleRootCA.crt \
     && update-ca-certificates \
     && rm /tmp/AppleRootCA.cer \
-    && apt-get purge -y openssl curl \
-    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/mautrix-imessage-v2 /usr/local/bin/mautrix-imessage-v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /build/mautrix-imessage-v2 /usr/local/bin/mautrix-imessage-v2
 
+WORKDIR /data
 VOLUME /data
 EXPOSE 29332
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,103 @@
+# ── Stage 1: builder ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake protobuf-compiler build-essential pkg-config \
+    git curl ca-certificates \
+    libolm-dev libclang-dev libssl-dev libunicorn-dev libheif-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust — install to default ~/.cargo so the Makefile's $(HOME)/.cargo/bin path resolves
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable
+ENV PATH=/root/.cargo/bin:$PATH
+
+# Go — arch-aware, fetches latest stable with fallback
+ARG TARGETARCH
+RUN set -e; \
+    GOARCH="${TARGETARCH:-amd64}"; \
+    GO_VERSION=$(curl -fsSL 'https://go.dev/dl/?mode=json' \
+        | grep -o '"version":"go[0-9.]*"' | head -1 \
+        | sed 's/"version":"//;s/"//'); \
+    : "${GO_VERSION:=go1.25.0}"; \
+    curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz" \
+        | tar -C /usr/local -xz
+ENV PATH=/usr/local/go/bin:$PATH \
+    GOTOOLCHAIN=local
+
+WORKDIR /build
+
+# ── Rust build layers ─────────────────────────────────────────────────────────
+# Copy files that determine whether the clone+patch layer is valid.
+# Changing the SHA pin, Makefile, or open-absinthe overlay invalidates this layer.
+COPY third_party/rustpush-upstream.sha third_party/
+COPY rustpush/ rustpush/
+COPY Makefile .
+
+# Clone upstream rustpush at the pinned SHA, apply all patches, overlay open-absinthe.
+RUN make ensure-rustpush-source
+
+# Copy Rust crate sources. Changing these invalidates only the Rust build layer,
+# not the clone layer above.
+COPY pkg/rustpushgo/ pkg/rustpushgo/
+COPY nac-validation/ nac-validation/
+
+# Build the Rust static library (~3 min; cached when Rust source is unchanged).
+# hardware-key enables the unicorn-based x86 NAC emulator required on Linux
+# (both amd64 and arm64 — unicorn supports cross-arch x86 emulation).
+RUN cd pkg/rustpushgo && \
+    cargo build --release --features hardware-key && \
+    cp target/release/librustpushgo.a /build/librustpushgo.a
+
+# ── Go build layers ───────────────────────────────────────────────────────────
+# Download modules first so this layer is cached by go.mod/go.sum.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy Go source.
+COPY cmd/ cmd/
+COPY pkg/connector/ pkg/connector/
+COPY imessage/ imessage/
+COPY ipc/ ipc/
+
+# Build the bridge binary.
+ARG BUILD_VERSION=dev
+ARG BUILD_COMMIT=unknown
+RUN BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) && \
+    CGO_LDFLAGS="-L/build" \
+    go build \
+    -ldflags "-X main.Tag=${BUILD_VERSION} -X main.Commit=${BUILD_COMMIT} -X main.BuildTime=${BUILD_TIME}" \
+    -o /build/mautrix-imessage-v2 \
+    ./cmd/mautrix-imessage/
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime shared libraries the bridge binary needs at startup.
+# libunicorn2  — unicorn-engine x86 NAC emulator (hardware-key feature)
+# libheif1     — HEIC/HEIF conversion (linked at compile time even when disabled)
+# libolm3      — Matrix OLM encryption (mautrix bridgev2 framework)
+# libssl3      — OpenSSL (rustpush openssl crate dynamic link)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libunicorn2 libheif1 libolm3 libssl3 \
+    ca-certificates openssl curl \
+    && curl -fsSL 'https://www.apple.com/appleca/AppleIncRootCertificate.cer' \
+        -o /tmp/AppleRootCA.cer \
+    && openssl x509 -inform DER -in /tmp/AppleRootCA.cer \
+        -out /usr/local/share/ca-certificates/AppleRootCA.crt \
+    && update-ca-certificates \
+    && rm /tmp/AppleRootCA.cer \
+    && apt-get purge -y openssl curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/mautrix-imessage-v2 /usr/local/bin/mautrix-imessage-v2
+
+VOLUME /data
+EXPOSE 29332
+
+ENTRYPOINT ["mautrix-imessage-v2", "-c", "/data/config.yaml"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+services:
+  bridge:
+    image: ghcr.io/jasonlaguidice/imessage:latest
+    restart: unless-stopped
+    ports:
+      - "29332:29332"
+    environment:
+      XDG_DATA_HOME: /state
+    volumes:
+      - ./data:/data          # config.yaml, registration.yaml, bridge.db
+      - ./state:/state        # session.json, per-user anisette/trustedpeers/id_cache

--- a/pkg/connector/attachment_retrier.go
+++ b/pkg/connector/attachment_retrier.go
@@ -246,8 +246,8 @@ func (r *attachmentRetrier) deliverAsEdit(ctx context.Context, row *pendingAttac
 		Index:          row.AttIndex,
 	}
 
-	videoTranscoding := r.Client.Main.Config.VideoTranscoding
-	heicConversion := r.Client.Main.Config.HEICConversion
+	videoTranscoding := r.Client.videoTranscoding()
+	heicConversion := r.Client.heicConversion()
 	heicQuality := r.Client.Main.Config.HEICJPEGQuality
 
 	sender := r.Client.canonicalizeDMSender(portalKey, r.Client.makeEventSender(&senderCopy))

--- a/pkg/connector/chatdb.go
+++ b/pkg/connector/chatdb.go
@@ -233,7 +233,7 @@ func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessag
 			if att == nil {
 				continue
 			}
-			attCm, err := convertChatDBAttachment(ctx, params.Portal, intent, msg, att, c.Main.Config.VideoTranscoding, c.Main.Config.HEICConversion, c.Main.Config.HEICJPEGQuality)
+			attCm, err := convertChatDBAttachment(ctx, params.Portal, intent, msg, att, c.videoTranscoding(), c.heicConversion(), c.Main.Config.HEICJPEGQuality)
 			if err != nil {
 				log.Warn().Err(err).Str("guid", msg.GUID).Int("att_index", i).Msg("Failed to convert attachment, skipping")
 				continue
@@ -254,7 +254,7 @@ func (db *chatDB) FetchMessages(ctx context.Context, params bridgev2.FetchMessag
 			// If there's a Live Photo MOV companion on disk, bridge it too.
 			movAtt := chatDBResolveLivePhoto(att, log)
 			if movAtt.PathOnDisk != att.PathOnDisk {
-				movCm, movErr := convertChatDBAttachment(ctx, params.Portal, intent, msg, movAtt, c.Main.Config.VideoTranscoding, c.Main.Config.HEICConversion, c.Main.Config.HEICJPEGQuality)
+				movCm, movErr := convertChatDBAttachment(ctx, params.Portal, intent, msg, movAtt, c.videoTranscoding(), c.heicConversion(), c.Main.Config.HEICJPEGQuality)
 				if movErr != nil {
 					log.Warn().Err(movErr).Str("guid", msg.GUID).Int("att_index", i).Msg("Failed to convert Live Photo MOV companion, skipping")
 				} else {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -107,6 +107,56 @@ type restorePipelineOptions struct {
 
 const maxAttachmentRetries = 3
 
+func (c *IMClient) videoTranscoding() bool {
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.VideoTranscoding != nil {
+		return *meta.VideoTranscoding
+	}
+	return c.Main.Config.VideoTranscoding
+}
+
+func (c *IMClient) heicConversion() bool {
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.HEICConversion != nil {
+		return *meta.HEICConversion
+	}
+	return c.Main.Config.HEICConversion
+}
+
+func (c *IMClient) useCloudKitBackfill() bool {
+	if !c.Main.Config.UseCloudKitBackfill() {
+		return false
+	}
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.CloudKitBackfill != nil {
+		return *meta.CloudKitBackfill
+	}
+	return true
+}
+
+func (c *IMClient) externalCardDAVConfig() CardDAVConfig {
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.CardDAVEmail != "" && meta.CardDAVPasswordEncrypted != "" {
+		return CardDAVConfig{
+			Email:             meta.CardDAVEmail,
+			URL:               meta.CardDAVURL,
+			Username:          meta.CardDAVUsername,
+			PasswordEncrypted: meta.CardDAVPasswordEncrypted,
+		}
+	}
+	return c.Main.Config.CardDAV
+}
+
+func (c *IMClient) disableFaceTime() bool {
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.DisableFaceTime != nil {
+		return *meta.DisableFaceTime
+	}
+	return c.Main.Config.DisableFaceTime
+}
+
+func (c *IMClient) statusKitNotifications() bool {
+	if meta, ok := c.UserLogin.Metadata.(*UserLoginMetadata); ok && meta.StatusKitNotifications != nil {
+		return *meta.StatusKitNotifications
+	}
+	return c.Main.Config.StatusKitNotifications
+}
+
 // recordAttachmentFailure increments the retry count for a failed attachment.
 // Returns the updated entry so callers can log the retry count.
 func (c *IMClient) recordAttachmentFailure(recordName, errMsg string) *failedAttachmentEntry {
@@ -1042,7 +1092,7 @@ func (c *IMClient) Connect(ctx context.Context) {
 		}(c.handle)
 	}
 
-	if c.Main.Config.VideoTranscoding {
+	if c.videoTranscoding() {
 		if ffmpeg.Supported() {
 			log.Info().Msg("Video transcoding enabled (ffmpeg found)")
 		} else {
@@ -1050,7 +1100,7 @@ func (c *IMClient) Connect(ctx context.Context) {
 		}
 	}
 
-	if c.Main.Config.HEICConversion {
+	if c.heicConversion() {
 		log.Info().Msg("HEIC conversion enabled (libheif)")
 	}
 
@@ -1274,12 +1324,13 @@ func (c *IMClient) Connect(ctx context.Context) {
 
 	go c.maybeSendManagementRoomWelcome(context.Background(), log)
 
-	// Set up contact source: external CardDAV > local macOS > iCloud CardDAV
-	if c.Main.Config.CardDAV.IsConfigured() {
-		extContacts := newExternalCardDAVClient(c.Main.Config.CardDAV, log)
+	// Set up contact source: external CardDAV (per-user or global) > local macOS > iCloud CardDAV
+	cardDAVCfg := c.externalCardDAVConfig()
+	if cardDAVCfg.IsConfigured() {
+		extContacts := newExternalCardDAVClient(cardDAVCfg, log)
 		if extContacts != nil {
 			c.contacts = extContacts
-			log.Info().Str("email", c.Main.Config.CardDAV.Email).Msg("Using external CardDAV for contacts")
+			log.Info().Str("email", cardDAVCfg.Email).Msg("Using external CardDAV for contacts")
 			if syncErr := c.contacts.SyncContacts(log); syncErr != nil {
 				log.Warn().Err(syncErr).Msg("Initial external CardDAV sync failed")
 			} else {
@@ -1333,7 +1384,7 @@ func (c *IMClient) Connect(ctx context.Context) {
 		}
 		// No CloudKit gate needed — open immediately
 		c.setCloudSyncDone()
-	} else if cloudStoreReady && c.Main.Config.UseCloudKitBackfill() {
+	} else if cloudStoreReady && c.useCloudKitBackfill() {
 		c.startCloudSyncController(log)
 	} else {
 		if !c.Main.Config.CloudKitBackfill {
@@ -1488,7 +1539,7 @@ func (c *IMClient) OnStatusUpdate(user string, mode *string, available bool) {
 		Str("user", user).
 		Logger()
 
-	if !c.Main.Config.StatusKitNotifications {
+	if !c.statusKitNotifications() {
 		log.Debug().Msg("StatusKit notifications disabled in config — dropping update")
 		return
 	}
@@ -2818,7 +2869,7 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 					*data.Attachment.MmcsDescriptorJson != "" {
 					c.enqueuePendingMMCSRecovery(ctx, portal, data)
 				}
-				return convertAttachment(ctx, portal, intent, data, c.Main.Config.VideoTranscoding, c.Main.Config.HEICConversion, c.Main.Config.HEICJPEGQuality)
+				return convertAttachment(ctx, portal, intent, data, c.videoTranscoding(), c.heicConversion(), c.Main.Config.HEICJPEGQuality)
 			},
 		})
 	}
@@ -3358,7 +3409,7 @@ func (c *IMClient) handleNotifyAnyways(log zerolog.Logger, msg rustpushgo.Wrappe
 	if strings.HasPrefix(rawText, faceTimeRingMarker) ||
 		strings.HasPrefix(rawText, faceTimeMissedMarker) ||
 		strings.HasPrefix(rawText, faceTimeAnsweredElsewhereMarker) {
-		if c.Main.Config.DisableFaceTime {
+		if c.disableFaceTime() {
 			return
 		}
 		switch {
@@ -3773,7 +3824,7 @@ func (c *IMClient) handleChatDelete(log zerolog.Logger, msg rustpushgo.WrappedMe
 	}
 
 	// chatdb backend: preserve master behavior — ignore Apple-initiated deletes.
-	if !c.Main.Config.UseCloudKitBackfill() {
+	if !c.useCloudKitBackfill() {
 		log.Info().Str("delete_type", deleteType).Msg("Ignoring incoming Apple chat delete (chatdb backend)")
 		return
 	}
@@ -3827,7 +3878,7 @@ func (c *IMClient) handleChatDelete(log zerolog.Logger, msg rustpushgo.WrappedMe
 
 func (c *IMClient) handleChatRecover(log zerolog.Logger, msg rustpushgo.WrappedMessage) {
 	// chatdb backend: no-op. Recovery is CloudKit-only.
-	if !c.Main.Config.UseCloudKitBackfill() {
+	if !c.useCloudKitBackfill() {
 		log.Debug().Msg("Ignoring RecoverChat (chatdb backend)")
 		return
 	}
@@ -4008,7 +4059,7 @@ func (c *IMClient) runRestoreBackfillPipeline(opts restorePipelineOptions) {
 		Str("source", opts.Source).
 		Logger()
 
-	if !c.Main.Config.UseCloudKitBackfill() || c.cloudStore == nil {
+	if !c.useCloudKitBackfill() || c.cloudStore == nil {
 		log.Warn().Msg("Restore pipeline started without CloudKit backfill; queueing plain ChatResync")
 		c.refreshRecoveredPortalAfterCloudSync(log, portalKey, opts.Source)
 		c.notifyRestoreStatus(opts, "Restore of **%s** queued.", displayName)
@@ -6004,7 +6055,7 @@ func (c *IMClient) HandleMatrixDeleteChat(ctx context.Context, msg *bridgev2.Mat
 
 	// Delete from Apple — CloudKit backend only. chatdb users should not have
 	// Apple-side chats deleted when they remove a portal from Beeper.
-	if c.Main.Config.UseCloudKitBackfill() {
+	if c.useCloudKitBackfill() {
 		c.deleteFromApple(portalID, conv, chatGuid, chatRecordNames, msgRecordNames)
 	}
 
@@ -6697,7 +6748,7 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 		return c.chatDB.FetchMessages(ctx, params, c)
 	}
 
-	if !c.Main.Config.UseCloudKitBackfill() || c.cloudStore == nil {
+	if !c.useCloudKitBackfill() || c.cloudStore == nil {
 		log.Debug().Bool("forward", params.Forward).Bool("backfill_enabled", c.Main.Config.CloudKitBackfill).
 			Msg("FetchMessages: backfill disabled or no cloud store, returning empty")
 		return &bridgev2.FetchMessagesResponse{HasMore: false, Forward: params.Forward}, nil
@@ -7633,7 +7684,7 @@ func (c *IMClient) downloadAndUploadAttachment(
 	}
 
 	// Remux/transcode non-MP4 videos to MP4 for broad Matrix client compatibility.
-	if c.Main.Config.VideoTranscoding && ffmpeg.Supported() && strings.HasPrefix(mimeType, "video/") && mimeType != "video/mp4" {
+	if c.videoTranscoding() && ffmpeg.Supported() && strings.HasPrefix(mimeType, "video/") && mimeType != "video/mp4" {
 		origMime := mimeType
 		origSize := len(data)
 		method := "remux"
@@ -7663,7 +7714,7 @@ func (c *IMClient) downloadAndUploadAttachment(
 
 	// Convert HEIC/HEIF images to JPEG since most Matrix clients can't display HEIC.
 	var heicImg image.Image
-	data, mimeType, fileName, heicImg = maybeConvertHEIC(&log, data, mimeType, fileName, c.Main.Config.HEICJPEGQuality, c.Main.Config.HEICConversion)
+	data, mimeType, fileName, heicImg = maybeConvertHEIC(&log, data, mimeType, fileName, c.Main.Config.HEICJPEGQuality, c.heicConversion())
 
 	// Convert non-JPEG images to JPEG and extract dimensions/thumbnail
 	var imgWidth, imgHeight int
@@ -7813,7 +7864,7 @@ func (c *IMClient) downloadAndUploadAttachment(
 		}
 
 		// Remux/transcode the avid video if enabled.
-		if c.Main.Config.VideoTranscoding && ffmpeg.Supported() {
+		if c.videoTranscoding() && ffmpeg.Supported() {
 			origSize := len(avidData)
 			method := "remux"
 			converted, convertErr := ffmpeg.ConvertBytes(ctx, avidData, ".mp4", nil,

--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -435,14 +436,9 @@ func clearLocalSessionBackup(log *zerolog.Logger) int {
 	pathFns := []func() (string, error){
 		sessionFilePath,
 		legacyIdentityFilePath,
-		trustedPeersFilePath,
 	}
 	removed := 0
-	for _, fn := range pathFns {
-		p, err := fn()
-		if err != nil {
-			continue
-		}
+	removeFile := func(p string) {
 		if err := os.Remove(p); err == nil {
 			removed++
 			if log != nil {
@@ -450,6 +446,28 @@ func clearLocalSessionBackup(log *zerolog.Logger) int {
 			}
 		} else if !os.IsNotExist(err) && log != nil {
 			log.Warn().Err(err).Str("path", p).Msg("Failed to remove session backup file during logout")
+		}
+	}
+	for _, fn := range pathFns {
+		p, err := fn()
+		if err != nil {
+			continue
+		}
+		removeFile(p)
+	}
+	// Remove all per-user trustedpeers_*.plist files (one per DSID).
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataDir = filepath.Join(home, ".local", "share")
+		}
+	}
+	if dataDir != "" {
+		pattern := filepath.Join(dataDir, "mautrix-imessage", "trustedpeers_*.plist")
+		if matches, err := filepath.Glob(pattern); err == nil {
+			for _, p := range matches {
+				removeFile(p)
+			}
 		}
 	}
 	return removed

--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -74,6 +74,7 @@ func BridgeCommands(disableFaceTime bool) []*commands.FullHandler {
 		cmdRestoreDebug,
 		cmdMsgDebug,
 		cmdContacts,
+		cmdSetCardDAV,
 	}
 	if !disableFaceTime {
 		cmds = append(cmds,
@@ -511,7 +512,7 @@ func fnRestoreChat(ce *commands.Event) {
 	}
 
 	// CloudKit backend: use delete-aware CloudKit restore.
-	if client.Main.Config.UseCloudKitBackfill() && client.cloudStore != nil {
+	if client.useCloudKitBackfill() && client.cloudStore != nil {
 		fnRestoreChatFromCloudKit(ce, login, client)
 		return
 	}
@@ -1063,7 +1064,7 @@ func (c *IMClient) restorePortalByID(_ context.Context, portalID string) error {
 		Receiver: c.UserLogin.ID,
 	}
 
-	if c.Main.Config.UseCloudKitBackfill() && c.cloudStore != nil {
+	if c.useCloudKitBackfill() && c.cloudStore != nil {
 		return c.startRestoreBackfillPipeline(restorePipelineOptions{
 			PortalID:       portalID,
 			PortalKey:      portalKey,
@@ -1115,7 +1116,7 @@ func fnRestoreDebug(ce *commands.Event) {
 		return
 	}
 
-	if !client.Main.Config.UseCloudKitBackfill() || client.cloudStore == nil {
+	if !client.useCloudKitBackfill() || client.cloudStore == nil {
 		ce.Reply("CloudKit backfill is not enabled.")
 		return
 	}
@@ -1236,7 +1237,7 @@ func fnMsgDebug(ce *commands.Event) {
 		ce.Reply("Bridge client not available.")
 		return
 	}
-	if !client.Main.Config.UseCloudKitBackfill() || client.cloudStore == nil {
+	if !client.useCloudKitBackfill() || client.cloudStore == nil {
 		ce.Reply("CloudKit backfill not enabled.")
 		return
 	}
@@ -1398,4 +1399,265 @@ func fnMsgDebug(ce *commands.Event) {
 	}
 
 	ce.Reply(sb.String())
+}
+
+
+// ============================================================================
+// set-carddav command
+// ============================================================================
+
+var cmdSetCardDAV = &commands.FullHandler{
+	Name:    "set-carddav",
+	Aliases: []string{"carddav"},
+	Func:    fnSetCardDAV,
+	Help: commands.HelpMeta{
+		Section:     commands.HelpSectionChats,
+		Description: "Change your contact sync source (iCloud, Google, Fastmail, Nextcloud, or other CardDAV)",
+	},
+	RequiresLogin: true,
+}
+
+func fnSetCardDAV(ce *commands.Event) {
+	ce.Reply("**Contact source**\n\n" +
+		"1. iCloud Contacts (uses your Apple ID — no setup needed)\n" +
+		"2. Google Contacts (requires a Google App Password)\n" +
+		"3. Fastmail (requires a Fastmail App Password)\n" +
+		"4. Nextcloud\n" +
+		"5. Other CardDAV server\n\n" +
+		"Reply with a number, or `$cmdprefix cancel` to cancel.")
+
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "set contact source",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			switch parseContactSource(strings.TrimSpace(ce.RawArgs)) {
+			case "1":
+				setCardDAVApplyConfig(ce, "", "", "", "")
+			case "2":
+				setCardDAVAskEmail(ce, "google")
+			case "3":
+				setCardDAVAskEmail(ce, "fastmail")
+			case "4":
+				setCardDAVAskNextcloudEmail(ce)
+			case "5":
+				setCardDAVAskOtherEmail(ce)
+			default:
+				ce.Reply("Invalid choice. Run `$cmdprefix set-carddav` to try again.")
+			}
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskEmail(ce *commands.Event, provider string) {
+	if provider == "google" {
+		ce.Reply("Enter your Google account email address:")
+	} else {
+		ce.Reply("Enter your Fastmail email address:")
+	}
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter email",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			email := strings.TrimSpace(ce.RawArgs)
+			if email == "" {
+				ce.Reply("Email cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskPassword(ce, provider, email)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskPassword(ce *commands.Event, provider, email string) {
+	if provider == "google" {
+		ce.Reply("Enter your Google App Password (not your regular Google password).\n\n" +
+			"Create one at myaccount.google.com/apppasswords — remove all spaces from the generated password.")
+	} else {
+		ce.Reply("Enter your Fastmail App Password (not your regular Fastmail password).\n\n" +
+			"Create one at Settings → Privacy & Security → App Passwords.")
+	}
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter password",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			password := strings.TrimSpace(ce.RawArgs)
+			if password == "" {
+				ce.Reply("Password cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			var url string
+			if provider == "google" {
+				url = "https://www.googleapis.com/carddav/v1/principals/" + email + "/lists/default/"
+			} else {
+				url = "https://carddav.fastmail.com/dav/addressbooks/user/" + email + "/Default/"
+			}
+			setCardDAVApplyConfig(ce, email, url, email, password)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskNextcloudEmail(ce *commands.Event) {
+	ce.Reply("Enter your Nextcloud username or email address:")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter nextcloud email",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			email := strings.TrimSpace(ce.RawArgs)
+			if email == "" {
+				ce.Reply("Email cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskNextcloudServerURL(ce, email)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskNextcloudServerURL(ce *commands.Event, email string) {
+	ce.Reply("Enter your Nextcloud server URL (e.g. https://cloud.example.com):")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter nextcloud server url",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			serverURL := strings.TrimSpace(ce.RawArgs)
+			if serverURL == "" {
+				ce.Reply("Server URL cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskNextcloudPassword(ce, email, serverURL)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskNextcloudPassword(ce *commands.Event, email, serverURL string) {
+	ce.Reply("Enter your Nextcloud password:")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter nextcloud password",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			password := strings.TrimSpace(ce.RawArgs)
+			if password == "" {
+				ce.Reply("Password cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			url := strings.TrimRight(serverURL, "/") + "/remote.php/dav"
+			setCardDAVApplyConfig(ce, email, url, email, password)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskOtherEmail(ce *commands.Event) {
+	ce.Reply("Enter your email address:")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter carddav email",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			email := strings.TrimSpace(ce.RawArgs)
+			if email == "" {
+				ce.Reply("Email cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskOtherURL(ce, email)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskOtherURL(ce *commands.Event, email string) {
+	ce.Reply("Enter your CardDAV server URL:")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter carddav url",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			url := strings.TrimSpace(ce.RawArgs)
+			if url == "" {
+				ce.Reply("URL cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskOtherUsername(ce, email, url)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskOtherUsername(ce *commands.Event, email, url string) {
+	ce.Reply("Enter your username (enter your email address if it is the same as your login):")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter carddav username",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			username := strings.TrimSpace(ce.RawArgs)
+			if username == "" {
+				ce.Reply("Username cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVAskOtherPassword(ce, email, url, username)
+		}),
+		Cancel: func() {},
+	})
+}
+
+func setCardDAVAskOtherPassword(ce *commands.Event, email, url, username string) {
+	ce.Reply("Enter your CardDAV password:")
+	commands.StoreCommandState(ce.User, &commands.CommandState{
+		Action: "enter carddav password",
+		Next: commands.MinimalCommandHandlerFunc(func(ce *commands.Event) {
+			commands.StoreCommandState(ce.User, nil)
+			password := strings.TrimSpace(ce.RawArgs)
+			if password == "" {
+				ce.Reply("Password cannot be empty. Run `$cmdprefix set-carddav` to try again.")
+				return
+			}
+			setCardDAVApplyConfig(ce, email, url, username, password)
+		}),
+		Cancel: func() {},
+	})
+}
+
+// setCardDAVApplyConfig encrypts the password, updates UserLoginMetadata, saves,
+// and tells the user to restart. Pass empty email to switch back to iCloud.
+func setCardDAVApplyConfig(ce *commands.Event, email, url, username, plainPassword string) {
+	login := ce.User.GetDefaultLogin()
+	if login == nil {
+		ce.Reply("No active login found.")
+		return
+	}
+	meta, ok := login.Metadata.(*UserLoginMetadata)
+	if !ok || meta == nil {
+		ce.Reply("Login metadata unavailable.")
+		return
+	}
+
+	if email == "" {
+		meta.CardDAVEmail = ""
+		meta.CardDAVURL = ""
+		meta.CardDAVUsername = ""
+		meta.CardDAVPasswordEncrypted = ""
+		if err := login.Save(ce.Ctx); err != nil {
+			ce.Reply("Failed to save settings: %v", err)
+			return
+		}
+		ce.Reply("Switched to iCloud contacts. **Restart the bridge to apply.**")
+		return
+	}
+
+	encrypted, err := EncryptCardDAVPassword(plainPassword)
+	if err != nil {
+		ce.Reply("Failed to encrypt password: %v", err)
+		return
+	}
+	meta.CardDAVEmail = email
+	meta.CardDAVURL = url
+	meta.CardDAVUsername = username
+	meta.CardDAVPasswordEncrypted = encrypted
+	if err := login.Save(ce.Ctx); err != nil {
+		ce.Reply("Failed to save settings: %v", err)
+		return
+	}
+	ce.Reply("CardDAV configured for **%s**. **Restart the bridge to apply.**", email)
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -133,7 +133,7 @@ func (c *IMConnector) tryAutoRestore(ctx context.Context) {
 	// Chat.db mode doesn't join the keychain clique (no CloudKit), so
 	// trustedpeers.plist is never written. Only require clique state
 	// when CloudKit backfill is active.
-	if c.Config.UseCloudKitBackfill() && !hasKeychainCliqueState(log) {
+	if c.Config.UseCloudKitBackfill() && !hasKeychainCliqueState(log, state.AccountDSID) {
 		log.Info().Msg("Skipping auto-restore: keychain trust circle not initialized (will require interactive login)")
 		return
 	}

--- a/pkg/connector/dbmeta.go
+++ b/pkg/connector/dbmeta.go
@@ -49,6 +49,21 @@ type UserLoginMetadata struct {
 	// (e.g. "tel:+15551234567" or "mailto:user@example.com").
 	PreferredHandle string `json:"preferred_handle,omitempty"`
 
+	// Per-user feature toggles — overrides the global config when non-nil.
+	// Set during the login flow; nil means "use global config default".
+	VideoTranscoding       *bool `json:"video_transcoding,omitempty"`
+	HEICConversion         *bool `json:"heic_conversion,omitempty"`
+	CloudKitBackfill       *bool `json:"cloudkit_backfill,omitempty"`
+	DisableFaceTime        *bool `json:"disable_facetime,omitempty"`
+	StatusKitNotifications *bool `json:"statuskit_notifications,omitempty"`
+
+	// Per-user external CardDAV configuration (optional).
+	// When set, used instead of iCloud contacts and the global config.yaml carddav section.
+	CardDAVEmail             string `json:"carddav_email,omitempty"`
+	CardDAVURL               string `json:"carddav_url,omitempty"`
+	CardDAVUsername          string `json:"carddav_username,omitempty"`
+	CardDAVPasswordEncrypted string `json:"carddav_password_encrypted,omitempty"`
+
 	// iCloud account persist data for TokenProvider restoration.
 	// Allows CardDAV contacts and CloudKit to work across restarts.
 	AccountUsername          string `json:"account_username,omitempty"`
@@ -62,6 +77,8 @@ type UserLoginMetadata struct {
 	// without needing to refresh (which requires a still-valid PET).
 	MmeDelegateJSON string `json:"mme_delegate_json,omitempty"`
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 func (c *IMConnector) GetDBMetaTypes() database.MetaTypes {
 	return database.MetaTypes{

--- a/pkg/connector/facetime.go
+++ b/pkg/connector/facetime.go
@@ -932,7 +932,7 @@ func (c *IMClient) maybeNotifyIncomingFaceTimeInvite(log zerolog.Logger, msg *ru
 	if msg == nil || senderIsFromMe || msg.IsStoredMessage {
 		return
 	}
-	if c.Main.Config.DisableFaceTime {
+	if c.disableFaceTime() {
 		return
 	}
 

--- a/pkg/connector/identity_store.go
+++ b/pkg/connector/identity_store.go
@@ -81,9 +81,9 @@ func legacyIdentityFilePath() (string, error) {
 	return filepath.Join(dataDir, "mautrix-imessage", "identity.plist"), nil
 }
 
-// trustedPeersFilePath returns the keychain trust state path:
-// ~/.local/share/mautrix-imessage/trustedpeers.plist
-func trustedPeersFilePath() (string, error) {
+// trustedPeersFilePath returns the per-user keychain trust state path:
+// ~/.local/share/mautrix-imessage/trustedpeers_<dsid>.plist
+func trustedPeersFilePath(dsid string) (string, error) {
 	dataDir := os.Getenv("XDG_DATA_HOME")
 	if dataDir == "" {
 		home, err := os.UserHomeDir()
@@ -92,13 +92,13 @@ func trustedPeersFilePath() (string, error) {
 		}
 		dataDir = filepath.Join(home, ".local", "share")
 	}
-	return filepath.Join(dataDir, "mautrix-imessage", "trustedpeers.plist"), nil
+	return filepath.Join(dataDir, "mautrix-imessage", "trustedpeers_"+dsid+".plist"), nil
 }
 
-// hasKeychainCliqueState returns true if trustedpeers.plist appears to contain
-// a keychain user identity (i.e. trust circle has been joined).
-func hasKeychainCliqueState(log zerolog.Logger) bool {
-	path, err := trustedPeersFilePath()
+// hasKeychainCliqueState returns true if the per-user trustedpeers.plist appears
+// to contain a keychain user identity (i.e. trust circle has been joined).
+func hasKeychainCliqueState(log zerolog.Logger, dsid string) bool {
+	path, err := trustedPeersFilePath(dsid)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to determine trusted peers file path")
 		return false
@@ -238,7 +238,7 @@ func CheckSessionRestore() bool {
 	if !session.validate(log) {
 		return false
 	}
-	if !hasKeychainCliqueState(log) {
+	if !hasKeychainCliqueState(log, state.AccountDSID) {
 		log.Info().Msg("Session restore check failed: keychain trust circle not initialized")
 		return false
 	}

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -35,6 +35,16 @@ const (
 	LoginStepDevicePasscode  = "fi.mau.imessage.login.device_passcode"
 	LoginStepSelectHandle    = "fi.mau.imessage.login.select_handle"
 	LoginStepComplete        = "fi.mau.imessage.login.complete"
+	LoginStepCloudKitBackfill = "fi.mau.imessage.login.cloudkit_backfill"
+	LoginStepVideoTranscoding = "fi.mau.imessage.login.video_transcoding"
+	LoginStepHEICConversion   = "fi.mau.imessage.login.heic_conversion"
+	LoginStepContactSource    = "fi.mau.imessage.login.contact_source"
+	LoginStepCardDAVGoogle    = "fi.mau.imessage.login.carddav_google"
+	LoginStepCardDAVFastmail  = "fi.mau.imessage.login.carddav_fastmail"
+	LoginStepCardDAVNextcloud = "fi.mau.imessage.login.carddav_nextcloud"
+	LoginStepCardDAVOther     = "fi.mau.imessage.login.carddav_other"
+	LoginStepFaceTime         = "fi.mau.imessage.login.facetime"
+	LoginStepStatusKit        = "fi.mau.imessage.login.statuskit"
 )
 
 // AppleIDLogin implements the multi-step login flow:
@@ -50,6 +60,16 @@ type AppleIDLogin struct {
 	handle         string                                 // chosen handle
 	devices        []rustpushgo.EscrowDeviceInfo          // escrow devices (fetched after IDS registration)
 	selectedDevice int                                    // index into devices (-1 = not yet selected)
+	cloudKitBackfill         bool
+	videoTranscoding         bool
+	heicConversion           bool
+	disableFaceTime          bool
+	statusKitNotifications   bool
+	handleSelected           bool
+	cardDAVEmail             string
+	cardDAVURL               string
+	cardDAVUsername          string
+	cardDAVPasswordEncrypted string
 }
 
 var _ bridgev2.LoginProcessUserInput = (*AppleIDLogin)(nil)
@@ -94,6 +114,97 @@ func (l *AppleIDLogin) Start(ctx context.Context) (*bridgev2.LoginStep, error) {
 }
 
 func (l *AppleIDLogin) SubmitUserInput(ctx context.Context, input map[string]string) (*bridgev2.LoginStep, error) {
+	// Post-handle steps (video transcoding, HEIC conversion, CardDAV setup, FaceTime, StatusKit)
+	if l.handleSelected {
+		// Other CardDAV: has carddav_url field (all 4 required)
+		if url, ok := input["carddav_url"]; ok {
+			encrypted, err := EncryptCardDAVPassword(input["carddav_password"])
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			l.cardDAVEmail = input["carddav_email"]
+			l.cardDAVURL = url
+			l.cardDAVUsername = input["carddav_username"]
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Nextcloud: has nextcloud_server_url field; derive CardDAV URL
+		if serverURL, ok := input["nextcloud_server_url"]; ok {
+			encrypted, err := EncryptCardDAVPassword(input["carddav_password"])
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = strings.TrimRight(serverURL, "/") + "/remote.php/dav"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Fastmail: has fastmail_app_password field; derive CardDAV URL
+		if pw, ok := input["fastmail_app_password"]; ok {
+			encrypted, err := EncryptCardDAVPassword(pw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = "https://carddav.fastmail.com/dav/addressbooks/user/" + email + "/Default/"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Google: has google_app_password field; derive CardDAV URL
+		if pw, ok := input["google_app_password"]; ok {
+			encrypted, err := EncryptCardDAVPassword(pw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = "https://www.googleapis.com/carddav/v1/principals/" + email + "/lists/default/"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Contact source picker response
+		if raw, ok := input["contact_source"]; ok {
+			source := parseContactSource(raw)
+			switch source {
+			case "1": // iCloud — no external CardDAV needed
+				return l.askFaceTimeStep()
+			case "2":
+				return l.askCardDAVGoogleStep()
+			case "3":
+				return l.askCardDAVFastmailStep()
+			case "4":
+				return l.askCardDAVNextcloudStep()
+			case "5":
+				return l.askCardDAVOtherStep()
+			}
+			return l.askFaceTimeStep()
+		}
+		if ft, ok := input["facetime_bridge"]; ok {
+			disabled := ft == "no"
+			l.disableFaceTime = disabled
+			return l.askStatusKitStep()
+		}
+		if sk, ok := input["statuskit_notifications"]; ok {
+			enabled := sk == "yes"
+			l.statusKitNotifications = enabled
+			return l.completeLogin(ctx)
+		}
+		if hc, ok := input["heic_conversion"]; ok {
+			l.heicConversion = hc == "yes"
+			return l.askContactSourceStep()
+		}
+		if vt, ok := input["video_transcoding"]; ok {
+			l.videoTranscoding = vt == "yes"
+			return l.askHEICConversionStep()
+		}
+		return l.completeLogin(ctx)
+	}
+
 	// Device passcode step (after device selection, before handle selection)
 	if passcode, ok := input["passcode"]; ok && l.result != nil {
 		return l.handlePasscodeAndContinue(ctx, passcode)
@@ -104,10 +215,16 @@ func (l *AppleIDLogin) SubmitUserInput(ctx context.Context, input map[string]str
 		return l.handleDeviceSelection(device)
 	}
 
-	// Handle selection step (after device passcode)
+	// CloudKit backfill preference (only when globally enabled, before device steps)
+	if ck, ok := input["cloudkit_backfill"]; ok && l.result != nil {
+		return l.handleCloudKitBackfillChoice(ctx, ck)
+	}
+
+	// Handle selection step (catch-all when IDS registration is done)
 	if l.result != nil {
 		l.handle = parseHandleSelection(input["handle"], l.result.Users.GetHandles())
-		return l.completeLogin(ctx)
+		l.handleSelected = true
+		return l.askVideoTranscodingStep()
 	}
 
 	// Step 1: Apple ID + password
@@ -203,10 +320,9 @@ func (l *AppleIDLogin) finishLogin(ctx context.Context) (*bridgev2.LoginStep, er
 	l.result = &result
 	l.selectedDevice = -1
 
-	// Skip device selection and passcode when CloudKit backfill is disabled —
-	// iCloud Keychain is only needed for decrypting CloudKit message records.
+	// When CloudKit is globally disabled, skip device/passcode and CloudKit question.
 	if !l.Main.Config.UseCloudKitBackfill() {
-		log.Info().Msg("CloudKit backfill disabled, skipping device selection and passcode")
+		log.Info().Msg("CloudKit backfill not available, skipping device selection and passcode")
 		handles := l.result.Users.GetHandles()
 		if step := handleSelectionStep(handles); step != nil {
 			return step, nil
@@ -214,10 +330,12 @@ func (l *AppleIDLogin) finishLogin(ctx context.Context) (*bridgev2.LoginStep, er
 		if len(handles) > 0 {
 			l.handle = handles[0]
 		}
-		return l.completeLogin(ctx)
+		l.handleSelected = true
+		return l.askVideoTranscodingStep()
 	}
 
-	return fetchDevicesAndPrompt(log, l.result.TokenProvider, &l.devices, &l.selectedDevice)
+	// Ask the user whether they want CloudKit backfill before showing device steps.
+	return l.askCloudKitBackfillStep()
 }
 
 func (l *AppleIDLogin) handleDeviceSelection(device string) (*bridgev2.LoginStep, error) {
@@ -238,20 +356,120 @@ func (l *AppleIDLogin) handlePasscodeAndContinue(ctx context.Context, passcode s
 	if len(handles) > 0 {
 		l.handle = handles[0]
 	}
-	return l.completeLogin(ctx)
+	l.handleSelected = true
+	return l.askVideoTranscodingStep()
 }
 
 func (l *AppleIDLogin) completeLogin(ctx context.Context) (*bridgev2.LoginStep, error) {
+	var cloudKitPref *bool
+	if l.Main.Config.UseCloudKitBackfill() {
+		cloudKitPref = boolPtr(l.cloudKitBackfill)
+	}
 	meta := &UserLoginMetadata{
-		Platform:        "rustpush-local",
-		APSState:        l.conn.State().ToString(),
-		IDSUsers:        l.result.Users.ToString(),
-		IDSIdentity:     l.result.Identity.ToString(),
-		DeviceID:        l.cfg.GetDeviceId(),
-		PreferredHandle: l.handle,
+		Platform:                 "rustpush-local",
+		APSState:                 l.conn.State().ToString(),
+		IDSUsers:                 l.result.Users.ToString(),
+		IDSIdentity:              l.result.Identity.ToString(),
+		DeviceID:                 l.cfg.GetDeviceId(),
+		PreferredHandle:          l.handle,
+		VideoTranscoding:         boolPtr(l.videoTranscoding),
+		HEICConversion:           boolPtr(l.heicConversion),
+		CloudKitBackfill:         cloudKitPref,
+		DisableFaceTime:          boolPtr(l.disableFaceTime),
+		StatusKitNotifications:   boolPtr(l.statusKitNotifications),
+		CardDAVEmail:             l.cardDAVEmail,
+		CardDAVURL:               l.cardDAVURL,
+		CardDAVUsername:          l.cardDAVUsername,
+		CardDAVPasswordEncrypted: l.cardDAVPasswordEncrypted,
 	}
 
 	return completeLoginWithMeta(ctx, l.User, l.Main, l.username, l.cfg, l.conn, l.result, meta)
+}
+
+func (l *AppleIDLogin) askContactSourceStep() (*bridgev2.LoginStep, error) {
+	return askContactSourceStep()
+}
+
+func (l *AppleIDLogin) askFaceTimeStep() (*bridgev2.LoginStep, error)  { return askFaceTimeStep() }
+func (l *AppleIDLogin) askStatusKitStep() (*bridgev2.LoginStep, error) { return askStatusKitStep() }
+
+func (l *AppleIDLogin) askCardDAVGoogleStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVGoogleStep()
+}
+
+func (l *AppleIDLogin) askCardDAVFastmailStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVFastmailStep()
+}
+
+func (l *AppleIDLogin) askCardDAVNextcloudStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVNextcloudStep()
+}
+
+func (l *AppleIDLogin) askCardDAVOtherStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVOtherStep()
+}
+
+func (l *AppleIDLogin) askCloudKitBackfillStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCloudKitBackfill,
+		Instructions: "Enable CloudKit history backfill? (yes/no)\n\n" +
+			"Syncs your full iMessage history from iCloud. " +
+			"If enabled, you will be asked for a device passcode to join your iCloud Keychain.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "cloudkit_backfill",
+				Name: "Enable CloudKit backfill? (yes/no)",
+			}},
+		},
+	}, nil
+}
+
+func (l *AppleIDLogin) handleCloudKitBackfillChoice(ctx context.Context, choice string) (*bridgev2.LoginStep, error) {
+	l.cloudKitBackfill = choice == "yes"
+	if l.cloudKitBackfill {
+		log := l.Main.Bridge.Log.With().Str("component", "imessage").Logger()
+		return fetchDevicesAndPrompt(log, l.result.TokenProvider, &l.devices, &l.selectedDevice)
+	}
+	handles := l.result.Users.GetHandles()
+	if step := handleSelectionStep(handles); step != nil {
+		return step, nil
+	}
+	if len(handles) > 0 {
+		l.handle = handles[0]
+	}
+	l.handleSelected = true
+	return l.askVideoTranscodingStep()
+}
+
+func (l *AppleIDLogin) askVideoTranscodingStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepVideoTranscoding,
+		Instructions: "Enable video transcoding? (yes/no)\n\n" +
+			"Automatically remux incompatible video formats (e.g. MOV → MP4) before bridging to Matrix. Requires ffmpeg.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "video_transcoding",
+				Name: "Enable video transcoding? (yes/no)",
+			}},
+		},
+	}, nil
+}
+
+func (l *AppleIDLogin) askHEICConversionStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepHEICConversion,
+		Instructions: "Enable HEIC→JPEG conversion? (yes/no)\n\n" +
+			"Automatically convert Apple HEIC images to JPEG for better Matrix client compatibility. Requires libheif.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "heic_conversion",
+				Name: "Enable HEIC conversion? (yes/no)",
+			}},
+		},
+	}, nil
 }
 
 // ============================================================================
@@ -272,6 +490,16 @@ type ExternalKeyLogin struct {
 	handle         string                                 // chosen handle
 	devices        []rustpushgo.EscrowDeviceInfo          // escrow devices (fetched after IDS registration)
 	selectedDevice int                                    // index into devices (-1 = not yet selected)
+	cloudKitBackfill         bool
+	videoTranscoding         bool
+	heicConversion           bool
+	disableFaceTime          bool
+	statusKitNotifications   bool
+	handleSelected           bool
+	cardDAVEmail             string
+	cardDAVURL               string
+	cardDAVUsername          string
+	cardDAVPasswordEncrypted string
 }
 
 var _ bridgev2.LoginProcessUserInput = (*ExternalKeyLogin)(nil)
@@ -296,6 +524,97 @@ func (l *ExternalKeyLogin) Start(ctx context.Context) (*bridgev2.LoginStep, erro
 }
 
 func (l *ExternalKeyLogin) SubmitUserInput(ctx context.Context, input map[string]string) (*bridgev2.LoginStep, error) {
+	// Post-handle steps (video transcoding, HEIC conversion, CardDAV setup, FaceTime, StatusKit)
+	if l.handleSelected {
+		// Other CardDAV: has carddav_url field (all 4 required)
+		if url, ok := input["carddav_url"]; ok {
+			encrypted, err := EncryptCardDAVPassword(input["carddav_password"])
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			l.cardDAVEmail = input["carddav_email"]
+			l.cardDAVURL = url
+			l.cardDAVUsername = input["carddav_username"]
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Nextcloud: has nextcloud_server_url field; derive CardDAV URL
+		if serverURL, ok := input["nextcloud_server_url"]; ok {
+			encrypted, err := EncryptCardDAVPassword(input["carddav_password"])
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = strings.TrimRight(serverURL, "/") + "/remote.php/dav"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Fastmail: has fastmail_app_password field; derive CardDAV URL
+		if pw, ok := input["fastmail_app_password"]; ok {
+			encrypted, err := EncryptCardDAVPassword(pw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = "https://carddav.fastmail.com/dav/addressbooks/user/" + email + "/Default/"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Google: has google_app_password field; derive CardDAV URL
+		if pw, ok := input["google_app_password"]; ok {
+			encrypted, err := EncryptCardDAVPassword(pw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt CardDAV password: %w", err)
+			}
+			email := input["carddav_email"]
+			l.cardDAVEmail = email
+			l.cardDAVURL = "https://www.googleapis.com/carddav/v1/principals/" + email + "/lists/default/"
+			l.cardDAVUsername = email
+			l.cardDAVPasswordEncrypted = encrypted
+			return l.askFaceTimeStep()
+		}
+		// Contact source picker response
+		if raw, ok := input["contact_source"]; ok {
+			source := parseContactSource(raw)
+			switch source {
+			case "1": // iCloud — no external CardDAV needed
+				return l.askFaceTimeStep()
+			case "2":
+				return l.askCardDAVGoogleStep()
+			case "3":
+				return l.askCardDAVFastmailStep()
+			case "4":
+				return l.askCardDAVNextcloudStep()
+			case "5":
+				return l.askCardDAVOtherStep()
+			}
+			return l.askFaceTimeStep()
+		}
+		if ft, ok := input["facetime_bridge"]; ok {
+			disabled := ft == "no"
+			l.disableFaceTime = disabled
+			return l.askStatusKitStep()
+		}
+		if sk, ok := input["statuskit_notifications"]; ok {
+			enabled := sk == "yes"
+			l.statusKitNotifications = enabled
+			return l.completeLogin(ctx)
+		}
+		if hc, ok := input["heic_conversion"]; ok {
+			l.heicConversion = hc == "yes"
+			return l.askContactSourceStep()
+		}
+		if vt, ok := input["video_transcoding"]; ok {
+			l.videoTranscoding = vt == "yes"
+			return l.askHEICConversionStep()
+		}
+		return l.completeLogin(ctx)
+	}
+
 	// Device passcode step (after device selection, before handle selection)
 	if passcode, ok := input["passcode"]; ok && l.result != nil {
 		return l.handlePasscodeAndContinue(ctx, passcode)
@@ -306,10 +625,16 @@ func (l *ExternalKeyLogin) SubmitUserInput(ctx context.Context, input map[string
 		return l.handleDeviceSelection(device)
 	}
 
-	// Handle selection step (after device passcode)
+	// CloudKit backfill preference (only when globally enabled, before device steps)
+	if ck, ok := input["cloudkit_backfill"]; ok && l.result != nil {
+		return l.handleCloudKitBackfillChoice(ctx, ck)
+	}
+
+	// Handle selection step (catch-all when IDS registration is done)
 	if l.result != nil {
 		l.handle = parseHandleSelection(input["handle"], l.result.Users.GetHandles())
-		return l.completeLogin(ctx)
+		l.handleSelected = true
+		return l.askVideoTranscodingStep()
 	}
 
 	// Step 1: Hardware key
@@ -450,10 +775,9 @@ func (l *ExternalKeyLogin) finishLogin(ctx context.Context) (*bridgev2.LoginStep
 	l.result = &result
 	l.selectedDevice = -1
 
-	// Skip device selection and passcode when CloudKit backfill is disabled —
-	// iCloud Keychain is only needed for decrypting CloudKit message records.
+	// When CloudKit is globally disabled, skip device/passcode and CloudKit question.
 	if !l.Main.Config.UseCloudKitBackfill() {
-		log.Info().Msg("CloudKit backfill disabled, skipping device selection and passcode")
+		log.Info().Msg("CloudKit backfill not available, skipping device selection and passcode")
 		handles := l.result.Users.GetHandles()
 		if step := handleSelectionStep(handles); step != nil {
 			return step, nil
@@ -461,10 +785,12 @@ func (l *ExternalKeyLogin) finishLogin(ctx context.Context) (*bridgev2.LoginStep
 		if len(handles) > 0 {
 			l.handle = handles[0]
 		}
-		return l.completeLogin(ctx)
+		l.handleSelected = true
+		return l.askVideoTranscodingStep()
 	}
 
-	return fetchDevicesAndPrompt(log, l.result.TokenProvider, &l.devices, &l.selectedDevice)
+	// Ask the user whether they want CloudKit backfill before showing device steps.
+	return l.askCloudKitBackfillStep()
 }
 
 func (l *ExternalKeyLogin) handleDeviceSelection(device string) (*bridgev2.LoginStep, error) {
@@ -485,21 +811,264 @@ func (l *ExternalKeyLogin) handlePasscodeAndContinue(ctx context.Context, passco
 	if len(handles) > 0 {
 		l.handle = handles[0]
 	}
-	return l.completeLogin(ctx)
+	l.handleSelected = true
+	return l.askVideoTranscodingStep()
 }
 
 func (l *ExternalKeyLogin) completeLogin(ctx context.Context) (*bridgev2.LoginStep, error) {
+	var cloudKitPref *bool
+	if l.Main.Config.UseCloudKitBackfill() {
+		cloudKitPref = boolPtr(l.cloudKitBackfill)
+	}
 	meta := &UserLoginMetadata{
-		Platform:        "rustpush-external-key",
-		APSState:        l.conn.State().ToString(),
-		IDSUsers:        l.result.Users.ToString(),
-		IDSIdentity:     l.result.Identity.ToString(),
-		DeviceID:        l.cfg.GetDeviceId(),
-		HardwareKey:     l.hardwareKey,
-		PreferredHandle: l.handle,
+		Platform:                 "rustpush-external-key",
+		APSState:                 l.conn.State().ToString(),
+		IDSUsers:                 l.result.Users.ToString(),
+		IDSIdentity:              l.result.Identity.ToString(),
+		DeviceID:                 l.cfg.GetDeviceId(),
+		HardwareKey:              l.hardwareKey,
+		PreferredHandle:          l.handle,
+		VideoTranscoding:         boolPtr(l.videoTranscoding),
+		HEICConversion:           boolPtr(l.heicConversion),
+		CloudKitBackfill:         cloudKitPref,
+		DisableFaceTime:          boolPtr(l.disableFaceTime),
+		StatusKitNotifications:   boolPtr(l.statusKitNotifications),
+		CardDAVEmail:             l.cardDAVEmail,
+		CardDAVURL:               l.cardDAVURL,
+		CardDAVUsername:          l.cardDAVUsername,
+		CardDAVPasswordEncrypted: l.cardDAVPasswordEncrypted,
 	}
 
 	return completeLoginWithMeta(ctx, l.User, l.Main, l.username, l.cfg, l.conn, l.result, meta)
+}
+
+func (l *ExternalKeyLogin) askContactSourceStep() (*bridgev2.LoginStep, error) {
+	return askContactSourceStep()
+}
+
+func (l *ExternalKeyLogin) askFaceTimeStep() (*bridgev2.LoginStep, error)  { return askFaceTimeStep() }
+func (l *ExternalKeyLogin) askStatusKitStep() (*bridgev2.LoginStep, error) { return askStatusKitStep() }
+
+func (l *ExternalKeyLogin) askCardDAVGoogleStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVGoogleStep()
+}
+
+func (l *ExternalKeyLogin) askCardDAVFastmailStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVFastmailStep()
+}
+
+func (l *ExternalKeyLogin) askCardDAVNextcloudStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVNextcloudStep()
+}
+
+func (l *ExternalKeyLogin) askCardDAVOtherStep() (*bridgev2.LoginStep, error) {
+	return askCardDAVOtherStep()
+}
+
+func (l *ExternalKeyLogin) askCloudKitBackfillStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCloudKitBackfill,
+		Instructions: "Enable CloudKit history backfill? (yes/no)\n\n" +
+			"Syncs your full iMessage history from iCloud. " +
+			"If enabled, you will be asked for a device passcode to join your iCloud Keychain.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "cloudkit_backfill",
+				Name: "Enable CloudKit backfill? (yes/no)",
+			}},
+		},
+	}, nil
+}
+
+func (l *ExternalKeyLogin) handleCloudKitBackfillChoice(ctx context.Context, choice string) (*bridgev2.LoginStep, error) {
+	l.cloudKitBackfill = choice == "yes"
+	if l.cloudKitBackfill {
+		log := l.Main.Bridge.Log.With().Str("component", "imessage").Logger()
+		return fetchDevicesAndPrompt(log, l.result.TokenProvider, &l.devices, &l.selectedDevice)
+	}
+	handles := l.result.Users.GetHandles()
+	if step := handleSelectionStep(handles); step != nil {
+		return step, nil
+	}
+	if len(handles) > 0 {
+		l.handle = handles[0]
+	}
+	l.handleSelected = true
+	return l.askVideoTranscodingStep()
+}
+
+func (l *ExternalKeyLogin) askVideoTranscodingStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepVideoTranscoding,
+		Instructions: "Enable video transcoding? (yes/no)\n\n" +
+			"Automatically remux incompatible video formats (e.g. MOV → MP4) before bridging to Matrix. Requires ffmpeg.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "video_transcoding",
+				Name: "Enable video transcoding? (yes/no)",
+			}},
+		},
+	}, nil
+}
+
+func (l *ExternalKeyLogin) askHEICConversionStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepHEICConversion,
+		Instructions: "Enable HEIC→JPEG conversion? (yes/no)\n\n" +
+			"Automatically convert Apple HEIC images to JPEG for better Matrix client compatibility. Requires libheif.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				ID:   "heic_conversion",
+				Name: "Enable HEIC conversion? (yes/no)",
+			}},
+		},
+	}, nil
+}
+
+// ============================================================================
+// FaceTime and StatusKit login step constructors (shared between login types)
+// ============================================================================
+
+func askFaceTimeStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:         bridgev2.LoginStepTypeUserInput,
+		StepID:       LoginStepFaceTime,
+		Instructions: "FaceTime Bridge: if you have an Apple device that already handles FaceTime natively, disabling this removes the !im facetime command and suppresses inbound FaceTime notices in bridge chats.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{
+					Type:    bridgev2.LoginInputFieldTypeSelect,
+					ID:      "facetime_bridge",
+					Name:    "Enable FaceTime Bridge",
+					Options: []string{"yes", "no"},
+				},
+			},
+		},
+	}, nil
+}
+
+func askStatusKitStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:         bridgev2.LoginStepTypeUserInput,
+		StepID:       LoginStepStatusKit,
+		Instructions: "StatusKit notifications: when enabled, the bridge posts a notice when a contact enables Focus or Do Not Disturb on their iPhone (the same indicator Apple's Messages app shows). Note: posting a notice will unarchive the destination chat.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{
+					Type:    bridgev2.LoginInputFieldTypeSelect,
+					ID:      "statuskit_notifications",
+					Name:    "Enable StatusKit notifications",
+					Options: []string{"yes", "no"},
+				},
+			},
+		},
+	}, nil
+}
+
+// ============================================================================
+// CardDAV login step constructors (shared between AppleIDLogin and ExternalKeyLogin)
+// ============================================================================
+
+// parseContactSource normalises the contact_source value to a bare digit ("1"–"5").
+// Accepts a bare digit, "N. label", or "N) label" as the bot may submit the full option text.
+func parseContactSource(raw string) string {
+	s := strings.TrimSpace(raw)
+	if len(s) > 0 && s[0] >= '1' && s[0] <= '5' {
+		return string(s[0])
+	}
+	return s
+}
+
+func askContactSourceStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepContactSource,
+		Instructions: "Choose a contact source for syncing contact names.\n\n" +
+			"1) iCloud Contacts (uses your Apple ID — no setup needed)\n" +
+			"2) Google Contacts (requires a Google App Password)\n" +
+			"3) Fastmail (requires a Fastmail App Password)\n" +
+			"4) Nextcloud\n" +
+			"5) Other CardDAV server\n\n" +
+			"Reply with the number.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{{
+				Type:    bridgev2.LoginInputFieldTypeSelect,
+				ID:      "contact_source",
+				Name:    "Contact source",
+				Options: []string{"1) iCloud Contacts", "2) Google Contacts", "3) Fastmail", "4) Nextcloud", "5) Other CardDAV server"},
+			}},
+		},
+	}, nil
+}
+
+func askCardDAVGoogleStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCardDAVGoogle,
+		Instructions: "Enter your Google Contacts credentials.\n\n" +
+			"You must use a Google App Password — your regular Google password will not work.\n" +
+			"Create one at: myaccount.google.com → Security → App Passwords\n" +
+			"Remove any spaces from the app password before entering it.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{Type: bridgev2.LoginInputFieldTypeEmail, ID: "carddav_email", Name: "Google account email"},
+				{Type: bridgev2.LoginInputFieldTypePassword, ID: "google_app_password", Name: "App Password (no spaces)"},
+			},
+		},
+	}, nil
+}
+
+func askCardDAVFastmailStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCardDAVFastmail,
+		Instructions: "Enter your Fastmail credentials.\n\n" +
+			"You must use a Fastmail App Password — your regular Fastmail password will not work.\n" +
+			"Create one at: Settings → Privacy & Security → App Passwords",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{Type: bridgev2.LoginInputFieldTypeEmail, ID: "carddav_email", Name: "Fastmail email"},
+				{Type: bridgev2.LoginInputFieldTypePassword, ID: "fastmail_app_password", Name: "App Password"},
+			},
+		},
+	}, nil
+}
+
+func askCardDAVNextcloudStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCardDAVNextcloud,
+		Instructions: "Enter your Nextcloud credentials.\n\n" +
+			"Server URL should be the base URL of your Nextcloud instance (e.g. https://cloud.example.com).\n" +
+			"The CardDAV path will be derived automatically.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{Type: bridgev2.LoginInputFieldTypeEmail, ID: "carddav_email", Name: "Nextcloud username / email"},
+				{ID: "nextcloud_server_url", Name: "Nextcloud server URL (e.g. https://cloud.example.com)"},
+				{Type: bridgev2.LoginInputFieldTypePassword, ID: "carddav_password", Name: "Password"},
+			},
+		},
+	}, nil
+}
+
+func askCardDAVOtherStep() (*bridgev2.LoginStep, error) {
+	return &bridgev2.LoginStep{
+		Type:   bridgev2.LoginStepTypeUserInput,
+		StepID: LoginStepCardDAVOther,
+		Instructions: "Enter your CardDAV server credentials.\n\n" +
+			"All fields are required. For username, enter your email address if it is the same as your login.",
+		UserInputParams: &bridgev2.LoginUserInputParams{
+			Fields: []bridgev2.LoginInputDataField{
+				{Type: bridgev2.LoginInputFieldTypeEmail, ID: "carddav_email", Name: "Email address"},
+				{ID: "carddav_url", Name: "CardDAV URL"},
+				{ID: "carddav_username", Name: "Username (enter your email if it is your login)"},
+				{Type: bridgev2.LoginInputFieldTypePassword, ID: "carddav_password", Name: "Password"},
+			},
+		},
+	}, nil
 }
 
 // ============================================================================

--- a/pkg/connector/sharedstreams.go
+++ b/pkg/connector/sharedstreams.go
@@ -693,7 +693,7 @@ func (c *IMClient) processSharedAlbumAsset(ctx context.Context, logger zerolog.L
 	}
 
 	// Video transcoding: non-MP4 → MP4
-	if c.Main.Config.VideoTranscoding && ffmpeg.Supported() && strings.HasPrefix(mimeType, "video/") && mimeType != "video/mp4" {
+	if c.videoTranscoding() && ffmpeg.Supported() && strings.HasPrefix(mimeType, "video/") && mimeType != "video/mp4" {
 		origMime := mimeType
 		method := "remux"
 		converted, convertErr := ffmpeg.ConvertBytes(ctx, data, ".mp4", nil,
@@ -716,7 +716,7 @@ func (c *IMClient) processSharedAlbumAsset(ctx context.Context, logger zerolog.L
 
 	// HEIC → JPEG
 	var heicImg image.Image
-	data, mimeType, fileName, heicImg = maybeConvertHEIC(&logger, data, mimeType, fileName, c.Main.Config.HEICJPEGQuality, c.Main.Config.HEICConversion)
+	data, mimeType, fileName, heicImg = maybeConvertHEIC(&logger, data, mimeType, fileName, c.Main.Config.HEICJPEGQuality, c.heicConversion())
 
 	// Image dimension extraction and thumbnail generation
 	var imgWidth, imgHeight int

--- a/pkg/rustpushgo/src/anisette.rs
+++ b/pkg/rustpushgo/src/anisette.rs
@@ -31,11 +31,9 @@
 //! accept the one-time 2FA prompt on next auth.
 
 use std::collections::HashMap;
-use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use futures::FutureExt;
 use log::{error, info, warn};
 use omnisette::remote_anisette_v3::RemoteAnisetteProviderV3;
 use omnisette::{AnisetteError, AnisetteProvider, LoginClientInfo};
@@ -81,18 +79,26 @@ impl AnisetteProvider for BridgeAnisetteProvider {
                     self.state_path.clone(),
                 );
 
-                // AssertUnwindSafe + catch_unwind turns upstream's bare
-                // `panic!()` into a caught panic payload. Without this the
-                // panic unwinds into the caller's critical section and can
-                // leave shared mutexes locked.
-                let inner = AssertUnwindSafe(upstream.get_anisette_headers()).catch_unwind();
+                // Move the upstream provider onto a blocking thread so the OS can
+                // preempt its non-yielding provisioning loop (upstream bug #2).
+                // We drive it with a fresh single-threaded runtime on that thread.
+                // Panics from the blocking thread surface as Err(JoinError) below,
+                // so AssertUnwindSafe/catch_unwind is no longer needed.
+                let result = tokio::task::spawn_blocking(move || {
+                    tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("failed to build anisette runtime")
+                        .block_on(upstream.get_anisette_headers())
+                });
+
                 // Preserve state.plist across every failure mode — wiping it
                 // mid-retry generates a fresh device identity on the next
                 // attempt, which Apple sees as a brand-new device and rejects
                 // the next login_email_pass with NeedsDevice2FA. The transient
                 // upstream errors below don't correlate with genuine state
                 // corruption, so we leave state alone and just retry.
-                match tokio::time::timeout(PROVISION_TIMEOUT, inner).await {
+                match tokio::time::timeout(PROVISION_TIMEOUT, result).await {
                     Ok(Ok(Ok(headers))) => {
                         info!(
                             "anisette: attempt {}/{} succeeded in {:?} (total {:?})",
@@ -103,67 +109,46 @@ impl AnisetteProvider for BridgeAnisetteProvider {
                         );
                         return Ok(headers);
                     }
-                    Ok(Ok(Err(AnisetteError::SerdeError(ref e)))) => {
+                    Ok(Ok(Err(AnisetteError::SerdeError(e)))) => {
                         warn!(
-                            "anisette: upstream serde error on attempt {}/{} (state preserved): {}",
+                            "anisette: serde error on attempt {}/{}: {}",
                             attempt + 1,
                             MAX_RETRIES,
                             e
                         );
-                        last_err = Some(AnisetteError::InvalidArgument(format!(
-                            "Anisette provisioning was rejected by the server \
-                             (attempt {}/{}). Error: {}",
-                            attempt + 1,
-                            MAX_RETRIES,
-                            e
-                        )));
+                        last_err = Some(AnisetteError::SerdeError(e));
                     }
                     Ok(Ok(Err(e))) => {
                         // Non-serde error — don't retry blindly.
                         return Err(e);
                     }
-                    Ok(Err(panic_payload)) => {
+                    Ok(Err(join_err)) => {
                         // Upstream `RemoteAnisetteProviderV3::get_anisette_headers`
                         // contains `panic!()` for non-`AnisetteNotProvisioned`
-                        // errors. Convert to a retryable error so the panic
-                        // doesn't unwind past this point. State preserved —
-                        // the panic is a control-flow bug in upstream, not a
-                        // sign that our identity is invalid.
-                        let msg = if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
-                            (*s).to_string()
-                        } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-                            s.clone()
-                        } else {
-                            "unknown panic payload".into()
-                        };
+                        // errors. The panic is caught by spawn_blocking as a
+                        // JoinError. State preserved — the panic is a
+                        // control-flow bug in upstream, not a sign that our
+                        // identity is invalid.
                         warn!(
-                            "anisette: upstream panicked on attempt {}/{} (state preserved): {}",
+                            "anisette: task panicked on attempt {}/{}: {:?}",
                             attempt + 1,
                             MAX_RETRIES,
-                            msg
+                            join_err
                         );
-                        last_err = Some(AnisetteError::InvalidArgument(format!(
-                            "Anisette call panicked (attempt {}/{}): {}",
-                            attempt + 1,
-                            MAX_RETRIES,
-                            msg
-                        )));
+                        last_err = Some(AnisetteError::InvalidArgument("anisette task panicked".to_string()));
                     }
-                    Err(_) => {
+                    Err(_timeout) => {
                         // Timeout — upstream's infinite-loop bug on WS drop.
+                        // Because the future runs on a blocking thread, the OS
+                        // can preempt it, so this timeout now fires reliably.
                         // Network-layer issue, not state corruption.
                         warn!(
-                            "anisette: upstream timed out on attempt {}/{} (state preserved, likely infinite loop on WS drop)",
+                            "anisette: timed out on attempt {}/{}",
                             attempt + 1,
                             MAX_RETRIES,
                         );
                         last_err = Some(AnisetteError::InvalidArgument(
-                            format!(
-                                "Anisette provisioning timed out (attempt {}/{}). \
-                                 The anisette server (ani.sidestore.io) may be down.",
-                                attempt + 1,
-                                MAX_RETRIES,
-                            ),
+                            "anisette provisioning timed out".to_string(),
                         ));
                     }
                 }

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -1510,7 +1510,7 @@ async fn create_keychain_clients(
         config: os_config.clone(),
         token_provider: token_provider.clone(),
     });
-    let keychain_state_path = format!("{}/trustedpeers.plist", resolve_xdg_data_dir());
+    let keychain_state_path = format!("{}/trustedpeers_{}.plist", resolve_xdg_data_dir(), dsid);
     let mut keychain_state: Option<rustpush::keychain::KeychainClientState> = match std::fs::read(&keychain_state_path) {
         Ok(data) => match plist::from_bytes(&data) {
             Ok(state) => Some(state),
@@ -2301,7 +2301,7 @@ pub async fn restore_token_provider(
     // broken `ProvisionInput` enum entirely (see src/anisette.rs). On
     // macOS this is upstream's native AOSKit path, unchanged.
     let client_info = os_config.get_gsa_config(&*conn.state.read().await, false);
-    let anisette_state_path = PathBuf::from_str("state/anisette").unwrap();
+    let anisette_state_path = PathBuf::from(format!("{}/anisette_{}", resolve_xdg_data_dir(), config.get_device_id()));
     let anisette = bridge_default_provider(client_info.clone(), anisette_state_path);
 
     // Create a new AppleAccount and populate it with persisted state
@@ -5262,7 +5262,7 @@ pub async fn login_start(
     info!("login_start: akd_user_agent={}", client_info.akd_user_agent);
     info!("login_start: hardware_headers={:?}", client_info.hardware_headers);
     info!("login_start: push_token={:?}", client_info.push_token);
-    let anisette_state_path = PathBuf::from_str("state/anisette").unwrap();
+    let anisette_state_path = PathBuf::from(format!("{}/anisette_{}", resolve_xdg_data_dir(), config.get_device_id()));
     let state_plist = anisette_state_path.join("state.plist");
     info!("login_start: anisette state path={:?} exists={}", state_plist, state_plist.exists());
 
@@ -6584,7 +6584,15 @@ pub async fn new_client(
     let identity_clone = identity.inner.clone();
     let config_clone = config.config.clone();
 
-    let _ = std::fs::create_dir_all("state");
+    let xdg_data_dir = resolve_xdg_data_dir();
+    let _ = std::fs::create_dir_all(&xdg_data_dir);
+    let cache_key = users_clone
+        .first()
+        .map(|u| u.user_id.chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '_' })
+            .collect::<String>())
+        .unwrap_or_else(|| "default".to_string());
+    let cache_path = format!("{}/id_cache_{}.plist", xdg_data_dir, cache_key);
 
     // FACETIME + VIDEO are in the bundle so the IdentityResource's `services`
     // slice contains them. Without that, upstream's `get_main_service` (called
@@ -6605,7 +6613,7 @@ pub async fn new_client(
             users_clone,
             identity_clone,
             &[&MADRID_SERVICE, &MULTIPLEX_SERVICE, &FACETIME_SERVICE, &VIDEO_SERVICE],
-            "state/id_cache.plist".into(),
+            cache_path.into(),
             config_clone.clone(),
             Box::new(move |updated_keys| {
                 update_users_callback.update_users(Arc::new(WrappedIDSUsers {
@@ -7621,7 +7629,7 @@ impl Client {
             token_provider: tp.inner.clone(),
         });
 
-        let keychain_state_path = format!("{}/trustedpeers.plist", resolve_xdg_data_dir());
+        let keychain_state_path = format!("{}/trustedpeers_{}.plist", resolve_xdg_data_dir(), dsid);
         let mut keychain_state: Option<rustpush::keychain::KeychainClientState> = match std::fs::read(&keychain_state_path) {
             Ok(data) => match plist::from_bytes(&data) {
                 Ok(state) => Some(state),

--- a/scripts/bootstrap-linux.sh
+++ b/scripts/bootstrap-linux.sh
@@ -36,8 +36,8 @@ APT_PACKAGES=$(echo "$APT_PACKAGES" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 if [ -n "$APT_PACKAGES" ]; then
     echo "Installing system packages:$APT_PACKAGES"
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq $APT_PACKAGES
+    apt-get update -qq
+    apt-get install -y -qq $APT_PACKAGES
     echo "✓ System packages installed"
 else
     echo "✓ System packages already installed"
@@ -92,8 +92,8 @@ install_go() {
     esac
     echo "  Downloading $GO_VERSION (linux/$ARCH)..."
     curl -sSL "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz
-    sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf /tmp/go.tar.gz
     rm -f /tmp/go.tar.gz
     export PATH="/usr/local/go/bin:$PATH"
     # Persist for future shells
@@ -126,9 +126,9 @@ if openssl s_client -connect identity.ess.apple.com:443 </dev/null 2>&1 | grep -
 else
     echo "Installing Apple Root CA..."
     wget -qO /tmp/AppleRootCA.cer 'https://www.apple.com/appleca/AppleIncRootCertificate.cer'
-    sudo openssl x509 -inform DER -in /tmp/AppleRootCA.cer \
+    openssl x509 -inform DER -in /tmp/AppleRootCA.cer \
         -out /usr/local/share/ca-certificates/AppleRootCA.crt
-    sudo update-ca-certificates --fresh >/dev/null 2>&1
+    update-ca-certificates --fresh >/dev/null 2>&1
     rm -f /tmp/AppleRootCA.cer
     echo "✓ Apple Root CA installed"
 fi

--- a/scripts/bootstrap-linux.sh
+++ b/scripts/bootstrap-linux.sh
@@ -36,8 +36,9 @@ APT_PACKAGES=$(echo "$APT_PACKAGES" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 
 if [ -n "$APT_PACKAGES" ]; then
     echo "Installing system packages:$APT_PACKAGES"
-    apt-get update -qq
-    apt-get install -y -qq $APT_PACKAGES
+    SUDO=""; [ "$(id -u)" != "0" ] && SUDO="sudo"
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y -qq $APT_PACKAGES
     echo "✓ System packages installed"
 else
     echo "✓ System packages already installed"
@@ -92,8 +93,8 @@ install_go() {
     esac
     echo "  Downloading $GO_VERSION (linux/$ARCH)..."
     curl -sSL "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz
-    rm -rf /usr/local/go
-    tar -C /usr/local -xzf /tmp/go.tar.gz
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf /tmp/go.tar.gz
     rm -f /tmp/go.tar.gz
     export PATH="/usr/local/go/bin:$PATH"
     # Persist for future shells
@@ -126,9 +127,9 @@ if openssl s_client -connect identity.ess.apple.com:443 </dev/null 2>&1 | grep -
 else
     echo "Installing Apple Root CA..."
     wget -qO /tmp/AppleRootCA.cer 'https://www.apple.com/appleca/AppleIncRootCertificate.cer'
-    openssl x509 -inform DER -in /tmp/AppleRootCA.cer \
+    sudo openssl x509 -inform DER -in /tmp/AppleRootCA.cer \
         -out /usr/local/share/ca-certificates/AppleRootCA.crt
-    update-ca-certificates --fresh >/dev/null 2>&1
+    sudo update-ca-certificates --fresh >/dev/null 2>&1
     rm -f /tmp/AppleRootCA.cer
     echo "✓ Apple Root CA installed"
 fi

--- a/scripts/install-beeper-linux.sh
+++ b/scripts/install-beeper-linux.sh
@@ -29,7 +29,7 @@ if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
     echo "✓ Stopped running bridge"
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    sudo systemctl stop mautrix-imessage
+    systemctl stop mautrix-imessage
     echo "✓ Stopped running bridge"
 fi
 
@@ -367,190 +367,6 @@ if [ "$CURRENT_BACKFILL" = "true" ]; then
     fi
 fi
 
-# ── Restore CardDAV config from backup ────────────────────────
-CARDDAV_BACKUP="$DATA_DIR/.carddav-config"
-if [ -f "$CARDDAV_BACKUP" ]; then
-    CHECK_EMAIL=$(grep 'email:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*email: *//;s/['\"]//g" | tr -d ' ' || true)
-    if [ -z "$CHECK_EMAIL" ]; then
-        source "$CARDDAV_BACKUP"
-        if [ -n "${SAVED_CARDDAV_EMAIL:-}" ] && [ -n "${SAVED_CARDDAV_ENC:-}" ]; then
-            python3 -c "
-import re
-text = open('$CONFIG').read()
-if 'carddav:' not in text:
-    lines = text.split('\\n')
-    insert_at = len(lines)
-    in_network = False
-    for i, line in enumerate(lines):
-        if line.startswith('network:'):
-            in_network = True
-            continue
-        if in_network and line and not line[0].isspace() and not line.startswith('#'):
-            insert_at = i
-            break
-    carddav = ['    carddav:', '        email: \"\"', '        url: \"\"', '        username: \"\"', '        password_encrypted: \"\"']
-    lines = lines[:insert_at] + carddav + lines[insert_at:]
-    text = '\\n'.join(lines)
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"$SAVED_CARDDAV_EMAIL\"')
-text = patch(text, 'url', '\"$SAVED_CARDDAV_URL\"')
-text = patch(text, 'username', '\"$SAVED_CARDDAV_USERNAME\"')
-text = patch(text, 'password_encrypted', '\"$SAVED_CARDDAV_ENC\"')
-open('$CONFIG', 'w').write(text)
-"
-            echo "✓ Restored CardDAV config: $SAVED_CARDDAV_EMAIL"
-        fi
-    fi
-fi
-
-# ── Contact source (runs every time, can reconfigure) ─────────
-if [ -t 0 ]; then
-    CURRENT_CARDDAV_EMAIL=$(grep 'email:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*email: *//;s/['\"]//g" | tr -d ' ' || true)
-    CONFIGURE_CARDDAV=false
-
-    if [ -n "$CURRENT_CARDDAV_EMAIL" ] && [ "$CURRENT_CARDDAV_EMAIL" != '""' ]; then
-        echo ""
-        echo "Contact source: External CardDAV ($CURRENT_CARDDAV_EMAIL)"
-        read -p "Change contact provider? [y/N]: " CHANGE_CONTACTS
-        case "$CHANGE_CONTACTS" in
-            [yY]*) CONFIGURE_CARDDAV=true ;;
-        esac
-    else
-        echo ""
-        echo "Contact source (for resolving names in chats):"
-        echo "  1) iCloud (default — uses your Apple ID)"
-        echo "  2) Google Contacts (requires app password)"
-        echo "  3) Fastmail"
-        echo "  4) Nextcloud"
-        echo "  5) Other CardDAV server"
-        read -p "Choice [1]: " CONTACT_CHOICE
-        CONTACT_CHOICE="${CONTACT_CHOICE:-1}"
-        if [ "$CONTACT_CHOICE" != "1" ]; then
-            CONFIGURE_CARDDAV=true
-        fi
-    fi
-
-    if [ "$CONFIGURE_CARDDAV" = true ]; then
-        # Show menu if we're changing from an existing provider
-        if [ -n "$CURRENT_CARDDAV_EMAIL" ] && [ "$CURRENT_CARDDAV_EMAIL" != '""' ]; then
-            echo ""
-            echo "  1) iCloud (remove external CardDAV)"
-            echo "  2) Google Contacts (requires app password)"
-            echo "  3) Fastmail"
-            echo "  4) Nextcloud"
-            echo "  5) Other CardDAV server"
-            read -p "Choice: " CONTACT_CHOICE
-        fi
-
-        CARDDAV_EMAIL=""
-        CARDDAV_PASSWORD=""
-        CARDDAV_USERNAME=""
-        CARDDAV_URL=""
-
-        if [ "${CONTACT_CHOICE:-}" = "1" ]; then
-            # Remove external CardDAV — clear the config fields
-            python3 -c "
-import re
-text = open('$CONFIG').read()
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"\"')
-text = patch(text, 'url', '\"\"')
-text = patch(text, 'username', '\"\"')
-text = patch(text, 'password_encrypted', '\"\"')
-open('$CONFIG', 'w').write(text)
-"
-            rm -f "$CARDDAV_BACKUP"
-            echo "✓ Switched to iCloud contacts"
-        elif [ -n "${CONTACT_CHOICE:-}" ]; then
-            read -p "Email address: " CARDDAV_EMAIL
-            if [ -z "$CARDDAV_EMAIL" ]; then
-                echo "ERROR: Email is required." >&2
-                exit 1
-            fi
-
-            case "$CONTACT_CHOICE" in
-                2)
-                    CARDDAV_URL="https://www.googleapis.com/carddav/v1/principals/$CARDDAV_EMAIL/lists/default/"
-                    echo "  Note: Use a Google App Password, without spaces (https://myaccount.google.com/apppasswords)"
-                    ;;
-                3)
-                    CARDDAV_URL="https://carddav.fastmail.com/dav/addressbooks/user/$CARDDAV_EMAIL/Default/"
-                    echo "  Note: Use a Fastmail App Password (Settings → Privacy & Security → App Passwords)"
-                    ;;
-                4)
-                    read -p "Nextcloud server URL (e.g. https://cloud.example.com): " NC_SERVER
-                    NC_SERVER="${NC_SERVER%/}"
-                    CARDDAV_URL="$NC_SERVER/remote.php/dav"
-                    ;;
-                5)
-                    read -p "CardDAV server URL: " CARDDAV_URL
-                    if [ -z "$CARDDAV_URL" ]; then
-                        echo "ERROR: URL is required." >&2
-                        exit 1
-                    fi
-                    ;;
-            esac
-
-            read -p "Username (leave empty to use email): " CARDDAV_USERNAME
-            read -s -p "App password: " CARDDAV_PASSWORD
-            echo ""
-            if [ -z "$CARDDAV_PASSWORD" ]; then
-                echo "ERROR: Password is required." >&2
-                exit 1
-            fi
-
-            # Encrypt password and patch config
-            CARDDAV_ARGS="--email $CARDDAV_EMAIL --password $CARDDAV_PASSWORD --url $CARDDAV_URL"
-            if [ -n "$CARDDAV_USERNAME" ]; then
-                CARDDAV_ARGS="$CARDDAV_ARGS --username $CARDDAV_USERNAME"
-            fi
-            CARDDAV_JSON=$("$BINARY" carddav-setup $CARDDAV_ARGS 2>/dev/null) || CARDDAV_JSON=""
-
-            if [ -z "$CARDDAV_JSON" ]; then
-                echo "⚠  CardDAV setup failed. You can configure it manually in $CONFIG"
-            else
-                CARDDAV_RESOLVED_URL=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
-                CARDDAV_ENC=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['password_encrypted'])")
-                EFFECTIVE_USERNAME="${CARDDAV_USERNAME:-$CARDDAV_EMAIL}"
-                python3 -c "
-import re
-text = open('$CONFIG').read()
-if 'carddav:' not in text:
-    lines = text.split('\\n')
-    insert_at = len(lines)
-    in_network = False
-    for i, line in enumerate(lines):
-        if line.startswith('network:'):
-            in_network = True
-            continue
-        if in_network and line and not line[0].isspace() and not line.startswith('#'):
-            insert_at = i
-            break
-    carddav = ['    carddav:', '        email: \"\"', '        url: \"\"', '        username: \"\"', '        password_encrypted: \"\"']
-    lines = lines[:insert_at] + carddav + lines[insert_at:]
-    text = '\\n'.join(lines)
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"$CARDDAV_EMAIL\"')
-text = patch(text, 'url', '\"$CARDDAV_RESOLVED_URL\"')
-text = patch(text, 'username', '\"$EFFECTIVE_USERNAME\"')
-text = patch(text, 'password_encrypted', '\"$CARDDAV_ENC\"')
-open('$CONFIG', 'w').write(text)
-"
-                echo "✓ CardDAV configured: $CARDDAV_EMAIL → $CARDDAV_RESOLVED_URL"
-                cat > "$CARDDAV_BACKUP" << BKEOF
-SAVED_CARDDAV_EMAIL="$CARDDAV_EMAIL"
-SAVED_CARDDAV_URL="$CARDDAV_RESOLVED_URL"
-SAVED_CARDDAV_USERNAME="$EFFECTIVE_USERNAME"
-SAVED_CARDDAV_ENC="$CARDDAV_ENC"
-BKEOF
-            fi
-        fi
-    fi
-fi
-
 # ── Brief init start (fresh install only) ────────────────────
 # On a fresh install with no prior session, start the bridge briefly so it
 # creates the DB schema and appears in Beeper as "stopped" during setup.
@@ -575,7 +391,7 @@ fi
 if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    sudo systemctl stop mautrix-imessage
+    systemctl stop mautrix-imessage
 fi
 
 # ── Check for existing login / prompt if needed ──────────────
@@ -611,15 +427,15 @@ fi
 # This catches upgrades from pre-keychain versions where the device-passcode
 # step was never run. If trustedpeers.plist exists with a user_identity, the
 # keychain was joined successfully and any transient PCS errors are harmless.
-TRUSTEDPEERS_FILE="$SESSION_DIR/trustedpeers.plist"
 FORCE_CLEAR_STATE=false
 if [ "$NEEDS_LOGIN" = "false" ]; then
     HAS_CLIQUE=false
-    if [ -f "$TRUSTEDPEERS_FILE" ]; then
-        if grep -q "<key>userIdentity</key>\|<key>user_identity</key>" "$TRUSTEDPEERS_FILE" 2>/dev/null; then
+    for _tp in "$SESSION_DIR"/trustedpeers*.plist; do
+        if [ -f "$_tp" ] && grep -q "<key>userIdentity</key>\|<key>user_identity</key>" "$_tp" 2>/dev/null; then
             HAS_CLIQUE=true
+            break
         fi
-    fi
+    done
 
     if [ "$HAS_CLIQUE" != "true" ]; then
         echo "⚠ Existing login found, but keychain trust-circle is not initialized."
@@ -629,80 +445,9 @@ if [ "$NEEDS_LOGIN" = "false" ]; then
     fi
 fi
 
-# ── Ensure video_transcoding key exists in config ──────────────
-if ! grep -q 'video_transcoding:' "$CONFIG" 2>/dev/null; then
-    sed -i '/cloudkit_backfill:/i\    video_transcoding: false' "$CONFIG"
-fi
-
-# ── Video transcoding (ffmpeg) ─────────────────────────────────
-CURRENT_VIDEO_TRANSCODING=$(grep 'video_transcoding:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*video_transcoding: *//' || true)
-if [ -t 0 ]; then
-    echo ""
-    echo "Video Transcoding:"
-    echo "  When enabled, non-MP4 videos (e.g. QuickTime .mov) are automatically"
-    echo "  converted to MP4 for broad Matrix client compatibility."
-    echo "  Requires ffmpeg."
-    echo ""
-    if [ "$CURRENT_VIDEO_TRANSCODING" = "true" ]; then
-        read -p "Enable video transcoding/remuxing? [Y/n]: " ENABLE_VT
-        case "$ENABLE_VT" in
-            [nN]*)
-                sed -i "s/video_transcoding: .*/video_transcoding: false/" "$CONFIG"
-                echo "✓ Video transcoding disabled"
-                ;;
-            *)
-                if ! command -v ffmpeg >/dev/null 2>&1; then
-                    echo "  ffmpeg not found — installing..."
-                    if command -v apt >/dev/null 2>&1; then
-                        sudo apt install -y ffmpeg
-                    elif command -v dnf >/dev/null 2>&1; then
-                        sudo dnf install -y ffmpeg
-                    elif command -v pacman >/dev/null 2>&1; then
-                        sudo pacman -S --noconfirm ffmpeg
-                    elif command -v zypper >/dev/null 2>&1; then
-                        sudo zypper install -y ffmpeg
-                    elif command -v apk >/dev/null 2>&1; then
-                        sudo apk add ffmpeg
-                    else
-                        echo "  ⚠ Could not detect package manager — please install ffmpeg manually"
-                    fi
-                fi
-                echo "✓ Video transcoding enabled"
-                ;;
-        esac
-    else
-        read -p "Enable video transcoding/remuxing? [y/N]: " ENABLE_VT
-        case "$ENABLE_VT" in
-            [yY]*)
-                sed -i "s/video_transcoding: .*/video_transcoding: true/" "$CONFIG"
-                if ! command -v ffmpeg >/dev/null 2>&1; then
-                    echo "  ffmpeg not found — installing..."
-                    if command -v apt >/dev/null 2>&1; then
-                        sudo apt install -y ffmpeg
-                    elif command -v dnf >/dev/null 2>&1; then
-                        sudo dnf install -y ffmpeg
-                    elif command -v pacman >/dev/null 2>&1; then
-                        sudo pacman -S --noconfirm ffmpeg
-                    elif command -v zypper >/dev/null 2>&1; then
-                        sudo zypper install -y ffmpeg
-                    elif command -v apk >/dev/null 2>&1; then
-                        sudo apk add ffmpeg
-                    else
-                        echo "  ⚠ Could not detect package manager — please install ffmpeg manually"
-                    fi
-                fi
-                echo "✓ Video transcoding enabled"
-                ;;
-            *)
-                echo "✓ Video transcoding disabled"
-                ;;
-        esac
-    fi
-fi
-
 # ── Ensure disable_facetime key exists in config ──────────────
 if ! grep -q 'disable_facetime:' "$CONFIG" 2>/dev/null; then
-    sed -i '/video_transcoding:/a\    disable_facetime: false' "$CONFIG"
+    sed -i '/cloudkit_backfill:/a\    disable_facetime: false' "$CONFIG"
 fi
 
 # ── Disable FaceTime Bridge (use native Apple FT instead) ────────
@@ -803,97 +548,6 @@ elif [ -t 0 ]; then
                 echo "✓ StatusKit notifications enabled"
                 ;;
         esac
-    fi
-fi
-
-# ── Ensure heic_conversion key exists in config ──────────────
-if ! grep -q 'heic_conversion:' "$CONFIG" 2>/dev/null; then
-    sed -i '/video_transcoding:/a\    heic_conversion: false' "$CONFIG"
-fi
-
-# ── HEIC conversion (libheif) ─────────────────────────────────
-CURRENT_HEIC_CONVERSION=$(grep 'heic_conversion:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_conversion: *//' || true)
-if [ -t 0 ]; then
-    echo ""
-    echo "HEIC Conversion:"
-    echo "  When enabled, HEIC/HEIF images are automatically converted to JPEG"
-    echo "  for broad Matrix client compatibility."
-    echo "  Requires libheif."
-    echo ""
-    if [ "$CURRENT_HEIC_CONVERSION" = "true" ]; then
-        read -p "Enable HEIC to JPEG conversion? [Y/n]: " ENABLE_HC
-        case "$ENABLE_HC" in
-            [nN]*)
-                sed -i "s/heic_conversion: .*/heic_conversion: false/" "$CONFIG"
-                echo "✓ HEIC conversion disabled"
-                ;;
-            *)
-                if command -v apt >/dev/null 2>&1; then
-                    dpkg -s libheif-dev >/dev/null 2>&1 || sudo apt install -y libheif-dev
-                elif command -v dnf >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo dnf install -y libheif-devel
-                elif command -v pacman >/dev/null 2>&1; then
-                    pacman -Qi libheif >/dev/null 2>&1 || sudo pacman -S --noconfirm libheif
-                elif command -v zypper >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo zypper install -y libheif-devel
-                elif command -v apk >/dev/null 2>&1; then
-                    apk info -e libheif-dev >/dev/null 2>&1 || sudo apk add libheif-dev
-                else
-                    echo "  ⚠ Could not detect package manager — please install libheif manually"
-                fi
-                echo "✓ HEIC conversion enabled"
-                ;;
-        esac
-    else
-        read -p "Enable HEIC to JPEG conversion? [y/N]: " ENABLE_HC
-        case "$ENABLE_HC" in
-            [yY]*)
-                sed -i "s/heic_conversion: .*/heic_conversion: true/" "$CONFIG"
-                if command -v apt >/dev/null 2>&1; then
-                    dpkg -s libheif-dev >/dev/null 2>&1 || sudo apt install -y libheif-dev
-                elif command -v dnf >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo dnf install -y libheif-devel
-                elif command -v pacman >/dev/null 2>&1; then
-                    pacman -Qi libheif >/dev/null 2>&1 || sudo pacman -S --noconfirm libheif
-                elif command -v zypper >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo zypper install -y libheif-devel
-                elif command -v apk >/dev/null 2>&1; then
-                    apk info -e libheif-dev >/dev/null 2>&1 || sudo apk add libheif-dev
-                else
-                    echo "  ⚠ Could not detect package manager — please install libheif manually"
-                fi
-                echo "✓ HEIC conversion enabled"
-                ;;
-            *)
-                echo "✓ HEIC conversion disabled"
-                ;;
-        esac
-    fi
-fi
-
-# ── HEIC JPEG quality (only if HEIC conversion is enabled) ───
-HEIC_ENABLED=$(grep 'heic_conversion:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_conversion: *//' || true)
-if [ "$HEIC_ENABLED" = "true" ]; then
-    if ! grep -q 'heic_jpeg_quality:' "$CONFIG" 2>/dev/null; then
-        sed -i '/heic_conversion:/a\    heic_jpeg_quality: 95' "$CONFIG"
-    fi
-else
-    sed -i '/heic_jpeg_quality:/d' "$CONFIG"
-fi
-if [ "$HEIC_ENABLED" = "true" ] && [ -t 0 ]; then
-    CURRENT_QUALITY=$(grep 'heic_jpeg_quality:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_jpeg_quality: *//' || echo "95")
-    [ -z "$CURRENT_QUALITY" ] && CURRENT_QUALITY=95
-    echo ""
-    read -p "JPEG quality for HEIC conversion (1–100) [$CURRENT_QUALITY]: " NEW_QUALITY
-    if [ -n "$NEW_QUALITY" ]; then
-        if [ "$NEW_QUALITY" -ge 1 ] 2>/dev/null && [ "$NEW_QUALITY" -le 100 ] 2>/dev/null; then
-            sed -i "s/heic_jpeg_quality: .*/heic_jpeg_quality: $NEW_QUALITY/" "$CONFIG"
-            echo "✓ JPEG quality set to $NEW_QUALITY"
-        else
-            echo "  ⚠ Invalid quality '$NEW_QUALITY' — keeping $CURRENT_QUALITY"
-        fi
-    else
-        echo "✓ JPEG quality: $CURRENT_QUALITY"
     fi
 fi
 
@@ -1028,13 +682,13 @@ if [ "$NEEDS_LOGIN" = "true" ]; then
     if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
         systemctl --user stop mautrix-imessage
     elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-        sudo systemctl stop mautrix-imessage
+        systemctl stop mautrix-imessage
     fi
 
     if [ "${FORCE_CLEAR_STATE:-false}" = "true" ]; then
         echo "Clearing stale local state before login..."
         rm -f "$DB_URI" "$DB_URI-wal" "$DB_URI-shm"
-        rm -f "$SESSION_DIR/session.json" "$SESSION_DIR/identity.plist" "$SESSION_DIR/trustedpeers.plist"
+        rm -f "$SESSION_DIR/session.json" "$SESSION_DIR/identity.plist" "$SESSION_DIR"/trustedpeers*.plist
     fi
 
     # Run login from DATA_DIR so that relative paths (state/anisette/)
@@ -1057,7 +711,113 @@ fi
 if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    sudo systemctl stop mautrix-imessage
+    systemctl stop mautrix-imessage
+fi
+
+# ── Contact source / CardDAV setup ───────────────────────────
+# Skip if login just ran — the login flow already asked about contact source.
+# On re-runs with an existing session, allow reconfiguration.
+# Reads and writes per-user metadata in the bridge DB (not config.yaml).
+if [ -t 0 ] && [ "${LOGIN_RAN:-false}" = "false" ] && command -v sqlite3 >/dev/null 2>&1 && [ -n "${DB_URI:-}" ] && [ -f "${DB_URI:-}" ]; then
+    CURRENT_CARDDAV_EMAIL=$(sqlite3 "$DB_URI" "SELECT coalesce(json_extract(metadata, '$.CardDAVEmail'), '') FROM user_login LIMIT 1;" 2>/dev/null || true)
+    CONFIGURE_CARDDAV=false
+
+    if [ -n "$CURRENT_CARDDAV_EMAIL" ]; then
+        echo ""
+        echo "Contact source: External CardDAV ($CURRENT_CARDDAV_EMAIL)"
+        read -p "Change contact provider? [y/N]: " CHANGE_CONTACTS
+        case "$CHANGE_CONTACTS" in
+            [yY]*) CONFIGURE_CARDDAV=true ;;
+        esac
+    else
+        echo ""
+        echo "Contact source (for resolving names in chats):"
+        echo "  1) iCloud (default — uses your Apple ID)"
+        echo "  2) Google Contacts (requires app password)"
+        echo "  3) Fastmail"
+        echo "  4) Nextcloud"
+        echo "  5) Other CardDAV server"
+        read -p "Choice [1]: " CONTACT_CHOICE
+        CONTACT_CHOICE="${CONTACT_CHOICE:-1}"
+        if [ "$CONTACT_CHOICE" != "1" ]; then
+            CONFIGURE_CARDDAV=true
+        fi
+    fi
+
+    if [ "$CONFIGURE_CARDDAV" = true ]; then
+        if [ -n "$CURRENT_CARDDAV_EMAIL" ]; then
+            echo ""
+            echo "  1) iCloud (remove external CardDAV)"
+            echo "  2) Google Contacts (requires app password)"
+            echo "  3) Fastmail"
+            echo "  4) Nextcloud"
+            echo "  5) Other CardDAV server"
+            read -p "Choice: " CONTACT_CHOICE
+        fi
+
+        CARDDAV_EMAIL=""
+        CARDDAV_PASSWORD=""
+        CARDDAV_USERNAME=""
+        CARDDAV_URL=""
+
+        if [ "${CONTACT_CHOICE:-}" = "1" ]; then
+            sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.CardDAVEmail', '', '$.CardDAVURL', '', '$.CardDAVUsername', '', '$.CardDAVPasswordEncrypted', '');"
+            echo "✓ Switched to iCloud contacts"
+        elif [ -n "${CONTACT_CHOICE:-}" ]; then
+            read -p "Email address: " CARDDAV_EMAIL
+            if [ -z "$CARDDAV_EMAIL" ]; then
+                echo "ERROR: Email is required." >&2
+                exit 1
+            fi
+
+            case "$CONTACT_CHOICE" in
+                2)
+                    CARDDAV_URL="https://www.googleapis.com/carddav/v1/principals/$CARDDAV_EMAIL/lists/default/"
+                    echo "  Note: Use a Google App Password, without spaces (https://myaccount.google.com/apppasswords)"
+                    ;;
+                3)
+                    CARDDAV_URL="https://carddav.fastmail.com/dav/addressbooks/user/$CARDDAV_EMAIL/Default/"
+                    echo "  Note: Use a Fastmail App Password (Settings → Privacy & Security → App Passwords)"
+                    ;;
+                4)
+                    read -p "Nextcloud server URL (e.g. https://cloud.example.com): " NC_SERVER
+                    NC_SERVER="${NC_SERVER%/}"
+                    CARDDAV_URL="$NC_SERVER/remote.php/dav"
+                    ;;
+                5)
+                    read -p "CardDAV server URL: " CARDDAV_URL
+                    if [ -z "$CARDDAV_URL" ]; then
+                        echo "ERROR: URL is required." >&2
+                        exit 1
+                    fi
+                    ;;
+            esac
+
+            read -p "Username (leave empty to use email): " CARDDAV_USERNAME
+            read -s -p "App password: " CARDDAV_PASSWORD
+            echo ""
+            if [ -z "$CARDDAV_PASSWORD" ]; then
+                echo "ERROR: Password is required." >&2
+                exit 1
+            fi
+
+            CARDDAV_ARGS="--email $CARDDAV_EMAIL --password $CARDDAV_PASSWORD --url $CARDDAV_URL"
+            if [ -n "$CARDDAV_USERNAME" ]; then
+                CARDDAV_ARGS="$CARDDAV_ARGS --username $CARDDAV_USERNAME"
+            fi
+            CARDDAV_JSON=$("$BINARY" carddav-setup $CARDDAV_ARGS 2>/dev/null) || CARDDAV_JSON=""
+
+            if [ -z "$CARDDAV_JSON" ]; then
+                echo "⚠  CardDAV setup failed. You can reconfigure with 'set-carddav' in the bridge bot."
+            else
+                CARDDAV_RESOLVED_URL=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
+                CARDDAV_ENC=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['password_encrypted'])")
+                EFFECTIVE_USERNAME="${CARDDAV_USERNAME:-$CARDDAV_EMAIL}"
+                sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.CardDAVEmail', '$CARDDAV_EMAIL', '$.CardDAVURL', '$CARDDAV_RESOLVED_URL', '$.CardDAVUsername', '$EFFECTIVE_USERNAME', '$.CardDAVPasswordEncrypted', '$CARDDAV_ENC');"
+                echo "✓ CardDAV configured: $CARDDAV_EMAIL → $CARDDAV_RESOLVED_URL"
+            fi
+        fi
+    fi
 fi
 
 # ── Optional shell shortcuts (asked before preferred handle so the
@@ -1071,8 +831,8 @@ if systemctl --user list-unit-files mautrix-imessage.service 2>/dev/null | grep 
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
 elif systemctl list-unit-files mautrix-imessage.service 2>/dev/null | grep -q mautrix-imessage; then
-    _SHORTCUT_SYSCTL="sudo systemctl"
-    _SHORTCUT_JCTL="sudo journalctl"
+    _SHORTCUT_SYSCTL="systemctl"
+    _SHORTCUT_JCTL="journalctl"
 else
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
@@ -1138,7 +898,6 @@ esac
 echo ""
 
 # ── Preferred handle (runs every time, can reconfigure) ────────
-HANDLE_BACKUP="$DATA_DIR/.preferred-handle"
 # Re-read in case login just set it
 CURRENT_HANDLE=$(grep 'preferred_handle:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*preferred_handle: *//;s/['\"]//g" | tr -d ' ' || true)
 
@@ -1149,9 +908,6 @@ if [ -z "$CURRENT_HANDLE" ]; then
     fi
     if [ -z "$CURRENT_HANDLE" ] && [ -f "$SESSION_DIR/session.json" ] && command -v python3 >/dev/null 2>&1; then
         CURRENT_HANDLE=$(python3 -c "import json; print(json.load(open('$SESSION_DIR/session.json')).get('preferred_handle',''))" 2>/dev/null || true)
-    fi
-    if [ -z "$CURRENT_HANDLE" ] && [ -f "$HANDLE_BACKUP" ]; then
-        CURRENT_HANDLE=$(cat "$HANDLE_BACKUP")
     fi
 fi
 
@@ -1204,15 +960,12 @@ if [ -t 0 ] && { [ "$LOGIN_RAN" != "true" ] || [ -z "$CURRENT_HANDLE" ]; }; then
     fi
 fi
 
-# Write preferred handle to config (add key if missing, patch if present)
+# Write preferred handle to DB
 if [ -n "${CURRENT_HANDLE:-}" ]; then
-    if grep -q 'preferred_handle:' "$CONFIG" 2>/dev/null; then
-        sed -i "s|preferred_handle: .*|preferred_handle: '$CURRENT_HANDLE'|" "$CONFIG"
-    else
-        sed -i "/^network:/a\\    preferred_handle: '$CURRENT_HANDLE'" "$CONFIG"
+    if command -v sqlite3 >/dev/null 2>&1 && [ -n "${DB_URI:-}" ] && [ -f "${DB_URI:-}" ]; then
+        sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.preferred_handle', '$CURRENT_HANDLE');"
     fi
     echo "✓ Preferred handle: $CURRENT_HANDLE"
-    echo "$CURRENT_HANDLE" > "$HANDLE_BACKUP"
 fi
 
 # ── Install / update systemd service ─────────────────────────
@@ -1238,7 +991,7 @@ fi
 install_systemd_user() {
     # Enable lingering so user services survive SSH session closures
     if command -v loginctl >/dev/null 2>&1 && [ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null)" != "yes" ]; then
-        sudo loginctl enable-linger "$USER" 2>/dev/null || true
+        loginctl enable-linger "$USER" 2>/dev/null || true
     fi
     mkdir -p "$(dirname "$USER_SERVICE_FILE")"
     cat > "$USER_SERVICE_FILE" << EOF

--- a/scripts/install-beeper-linux.sh
+++ b/scripts/install-beeper-linux.sh
@@ -29,7 +29,7 @@ if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
     echo "✓ Stopped running bridge"
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    systemctl stop mautrix-imessage
+    sudo systemctl stop mautrix-imessage
     echo "✓ Stopped running bridge"
 fi
 
@@ -391,7 +391,7 @@ fi
 if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    systemctl stop mautrix-imessage
+    sudo systemctl stop mautrix-imessage
 fi
 
 # ── Check for existing login / prompt if needed ──────────────
@@ -682,7 +682,7 @@ if [ "$NEEDS_LOGIN" = "true" ]; then
     if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
         systemctl --user stop mautrix-imessage
     elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-        systemctl stop mautrix-imessage
+        sudo systemctl stop mautrix-imessage
     fi
 
     if [ "${FORCE_CLEAR_STATE:-false}" = "true" ]; then
@@ -711,7 +711,7 @@ fi
 if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
     systemctl --user stop mautrix-imessage
 elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-    systemctl stop mautrix-imessage
+    sudo systemctl stop mautrix-imessage
 fi
 
 # ── Contact source / CardDAV setup ───────────────────────────
@@ -831,8 +831,8 @@ if systemctl --user list-unit-files mautrix-imessage.service 2>/dev/null | grep 
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
 elif systemctl list-unit-files mautrix-imessage.service 2>/dev/null | grep -q mautrix-imessage; then
-    _SHORTCUT_SYSCTL="systemctl"
-    _SHORTCUT_JCTL="journalctl"
+    _SHORTCUT_SYSCTL="sudo systemctl"
+    _SHORTCUT_JCTL="sudo journalctl"
 else
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
@@ -991,7 +991,7 @@ fi
 install_systemd_user() {
     # Enable lingering so user services survive SSH session closures
     if command -v loginctl >/dev/null 2>&1 && [ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null)" != "yes" ]; then
-        loginctl enable-linger "$USER" 2>/dev/null || true
+        sudo loginctl enable-linger "$USER" 2>/dev/null || true
     fi
     mkdir -p "$(dirname "$USER_SERVICE_FILE")"
     cat > "$USER_SERVICE_FILE" << EOF

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -102,111 +102,6 @@ if ! grep -q 'backfill_source:' "$CONFIG" 2>/dev/null; then
     sed -i '/cloudkit_backfill:/a\    backfill_source: cloudkit' "$CONFIG"
 fi
 
-# ── CloudKit backfill toggle (runs every time) ────────────────
-CURRENT_BACKFILL=$(grep 'cloudkit_backfill:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*cloudkit_backfill: *//' || true)
-if [ -t 0 ]; then
-    echo ""
-    echo "CloudKit Backfill:"
-    echo "  When enabled, the bridge will sync your iMessage history from iCloud."
-    echo "  This requires entering your device PIN during login to join the iCloud Keychain."
-    echo "  When disabled, only new real-time messages are bridged (no PIN needed)."
-    echo ""
-    if [ "$CURRENT_BACKFILL" = "true" ]; then
-        read -p "Enable CloudKit message history backfill? [Y/n]: " ENABLE_BACKFILL
-        case "$ENABLE_BACKFILL" in
-            [nN]*) ENABLE_BACKFILL=false ;;
-            *)     ENABLE_BACKFILL=true ;;
-        esac
-    else
-        read -p "Enable CloudKit message history backfill? [y/N]: " ENABLE_BACKFILL
-        case "$ENABLE_BACKFILL" in
-            [yY]*) ENABLE_BACKFILL=true ;;
-            *)     ENABLE_BACKFILL=false ;;
-        esac
-    fi
-    sed -i "s/cloudkit_backfill: .*/cloudkit_backfill: $ENABLE_BACKFILL/" "$CONFIG"
-    if [ "$ENABLE_BACKFILL" = "true" ]; then
-        echo "✓ CloudKit backfill enabled — you'll be asked for your device PIN during login"
-        echo ""
-        echo "IMPORTANT: Before starting the bridge, sync your latest messages to iCloud"
-        echo "from an Apple device (iPhone, iPad, or Mac) to ensure all recent messages"
-        echo "are available for backfill."
-        echo ""
-        read -p "Have you synced your Apple device to iCloud? [y/N]: " ICLOUD_SYNCED
-        case "$ICLOUD_SYNCED" in
-            [yY]*) echo "✓ Great — backfill will include your latest messages" ;;
-            *)     echo "⚠ Please sync your Apple device to iCloud before starting the bridge" ;;
-        esac
-    else
-        echo "✓ CloudKit backfill disabled — real-time messages only, no PIN needed"
-    fi
-fi
-
-# ── Max initial messages (new database + CloudKit backfill + interactive) ──
-CURRENT_BACKFILL=$(grep 'cloudkit_backfill:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*cloudkit_backfill: *//' || true)
-if [ "$CURRENT_BACKFILL" = "true" ] && [ -t 0 ]; then
-    DB_PATH=$(grep 'uri:' "$CONFIG" | head -1 | sed 's/.*uri: file://' | sed 's/?.*//')
-    if [ -z "$DB_PATH" ] || [ ! -f "$DB_PATH" ]; then
-        echo ""
-        echo "By default, all messages per chat will be backfilled."
-        echo "If you choose to limit, the minimum is 100 messages per chat."
-        read -p "Would you like to limit the number of messages? [y/N]: " LIMIT_MSGS
-        case "$LIMIT_MSGS" in
-            [yY]*)
-                while true; do
-                    read -p "Max messages per chat (minimum 100): " MAX_MSGS
-                    MAX_MSGS=$(echo "$MAX_MSGS" | tr -dc '0-9')
-                    if [ -n "$MAX_MSGS" ] && [ "$MAX_MSGS" -ge 100 ] 2>/dev/null; then
-                        break
-                    fi
-                    echo "Minimum is 100. Please enter a value of 100 or more."
-                done
-                sed -i "s/max_initial_messages: [0-9]*/max_initial_messages: $MAX_MSGS/" "$CONFIG"
-                # Disable backward backfill so the cap is the final word on message count
-                sed -i 's/max_batches: -1$/max_batches: 0/' "$CONFIG"
-                echo "✓ Max initial messages set to $MAX_MSGS per chat"
-                ;;
-            *)
-                echo "✓ Backfilling all messages"
-                ;;
-        esac
-    fi
-fi
-
-# Tune backfill settings when CloudKit backfill is enabled
-CURRENT_BACKFILL=$(grep 'cloudkit_backfill:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*cloudkit_backfill: *//' || true)
-if [ "$CURRENT_BACKFILL" = "true" ]; then
-    PATCHED_BACKFILL=false
-    # Only enable unlimited backward backfill when max_initial is uncapped.
-    # When the user caps max_initial_messages, max_batches stays at 0 so the
-    # bridge won't backfill beyond the cap.
-    if grep -q 'max_initial_messages: 2147483647' "$CONFIG" 2>/dev/null; then
-        if grep -q 'max_batches: 0$' "$CONFIG" 2>/dev/null; then
-            sed -i 's/max_batches: 0$/max_batches: -1/' "$CONFIG"
-            PATCHED_BACKFILL=true
-        fi
-    fi
-    if grep -q 'max_initial_messages: [0-9]\{1,2\}$' "$CONFIG" 2>/dev/null; then
-        sed -i 's/max_initial_messages: [0-9]*/max_initial_messages: 2147483647/' "$CONFIG"
-        PATCHED_BACKFILL=true
-    fi
-    if grep -q 'max_catchup_messages: [0-9]\{1,3\}$' "$CONFIG" 2>/dev/null; then
-        sed -i 's/max_catchup_messages: [0-9]*/max_catchup_messages: 5000/' "$CONFIG"
-        PATCHED_BACKFILL=true
-    fi
-    if grep -q 'batch_size: [0-9]\{1,3\}$' "$CONFIG" 2>/dev/null; then
-        sed -i 's/batch_size: [0-9]*/batch_size: 10000/' "$CONFIG"
-        PATCHED_BACKFILL=true
-    fi
-    if grep -q 'batch_delay: 0$' "$CONFIG" 2>/dev/null; then
-        sed -i 's/batch_delay: 0$/batch_delay: 1/' "$CONFIG"
-        PATCHED_BACKFILL=true
-    fi
-    if [ "$PATCHED_BACKFILL" = true ]; then
-        echo "✓ Updated backfill settings (max_initial=unlimited, batch_size=10000, max_batches=-1)"
-    fi
-fi
-
 # ── Generate registration ────────────────────────────────────
 if [ -f "$REGISTRATION" ]; then
     echo "✓ Registration already exists"
@@ -232,35 +127,79 @@ if [ "$FIRST_RUN" = true ]; then
     read -p "Press Enter once your homeserver is restarted..."
 fi
 
-# ── Restore CardDAV config from backup ────────────────────────
-CARDDAV_BACKUP="$DATA_DIR/.carddav-config"
-if [ -f "$CARDDAV_BACKUP" ]; then
-    CHECK_EMAIL=$(grep 'email:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*email: *//;s/['\"]//g" | tr -d ' ' || true)
-    if [ -z "$CHECK_EMAIL" ]; then
-        source "$CARDDAV_BACKUP"
-        if [ -n "${SAVED_CARDDAV_EMAIL:-}" ] && [ -n "${SAVED_CARDDAV_ENC:-}" ]; then
-            python3 -c "
-import re
-text = open('$CONFIG').read()
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"$SAVED_CARDDAV_EMAIL\"')
-text = patch(text, 'url', '\"$SAVED_CARDDAV_URL\"')
-text = patch(text, 'username', '\"$SAVED_CARDDAV_USERNAME\"')
-text = patch(text, 'password_encrypted', '\"$SAVED_CARDDAV_ENC\"')
-open('$CONFIG', 'w').write(text)
-"
-            echo "✓ Restored CardDAV config: $SAVED_CARDDAV_EMAIL"
+# ── Check for existing login / prompt if needed ──────────────
+DB_URI=$(grep 'uri:' "$CONFIG" | head -1 | sed 's/.*uri: file://' | sed 's/?.*//')
+NEEDS_LOGIN=false
+
+if [ -z "$DB_URI" ] || [ ! -f "$DB_URI" ]; then
+    NEEDS_LOGIN=true
+elif command -v sqlite3 >/dev/null 2>&1; then
+    LOGIN_COUNT=$(sqlite3 "$DB_URI" "SELECT count(*) FROM user_login;" 2>/dev/null || echo "0")
+    if [ "$LOGIN_COUNT" = "0" ]; then
+        NEEDS_LOGIN=true
+    fi
+else
+    # sqlite3 not available — can't verify DB has logins, assume login needed
+    NEEDS_LOGIN=true
+fi
+
+# Require re-login if keychain trust-circle state is missing.
+# This catches upgrades from pre-keychain versions where the device-passcode
+# step was never run. If trustedpeers.plist exists with a user_identity, the
+# keychain was joined successfully and any transient PCS errors are harmless.
+SESSION_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mautrix-imessage"
+FORCE_CLEAR_STATE=false
+if [ "$NEEDS_LOGIN" = "false" ]; then
+    HAS_CLIQUE=false
+    for _tp in "$SESSION_DIR"/trustedpeers*.plist; do
+        if [ -f "$_tp" ] && grep -q "<key>userIdentity</key>\|<key>user_identity</key>" "$_tp" 2>/dev/null; then
+            HAS_CLIQUE=true
+            break
         fi
+    done
+
+    if [ "$HAS_CLIQUE" != "true" ]; then
+        echo "⚠ Existing login found, but keychain trust-circle is not initialized."
+        echo "  Forcing fresh login so device-passcode step can run."
+        NEEDS_LOGIN=true
+        FORCE_CLEAR_STATE=true
     fi
 fi
 
-# ── Contact source (runs every time, can reconfigure) ─────────
-if [ -t 0 ]; then
-    CURRENT_CARDDAV_EMAIL=$(grep 'email:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*email: *//;s/['\"]//g" | tr -d ' ' || true)
+if [ "$NEEDS_LOGIN" = "true" ]; then
+    echo ""
+    echo "┌─────────────────────────────────────────────────┐"
+    echo "│  No valid iMessage login found — starting login │"
+    echo "└─────────────────────────────────────────────────┘"
+    echo ""
+    # Stop the bridge if running (otherwise it holds the DB lock)
+    if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
+        systemctl --user stop mautrix-imessage
+    elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
+        systemctl stop mautrix-imessage
+    fi
+
+    if [ "${FORCE_CLEAR_STATE:-false}" = "true" ]; then
+        echo "Clearing stale local state before login..."
+        rm -f "$DB_URI" "$DB_URI-wal" "$DB_URI-shm"
+        rm -f "$SESSION_DIR/session.json" "$SESSION_DIR/identity.plist" "$SESSION_DIR"/trustedpeers*.plist
+    fi
+
+    # Run login from DATA_DIR so that relative paths (state/anisette/)
+    # resolve to the same location as when systemd runs the bridge.
+    (cd "$DATA_DIR" && "$BINARY" login -c "$CONFIG")
+    echo ""
+fi
+
+# ── Contact source / CardDAV setup ───────────────────────────
+# Skip if login just ran — the login flow already asked about contact source.
+# On re-runs with an existing session, allow reconfiguration.
+# Reads and writes per-user metadata in the bridge DB (not config.yaml).
+if [ -t 0 ] && [ "$NEEDS_LOGIN" = "false" ] && command -v sqlite3 >/dev/null 2>&1 && [ -n "${DB_URI:-}" ] && [ -f "${DB_URI:-}" ]; then
+    CURRENT_CARDDAV_EMAIL=$(sqlite3 "$DB_URI" "SELECT coalesce(json_extract(metadata, '$.CardDAVEmail'), '') FROM user_login LIMIT 1;" 2>/dev/null || true)
     CONFIGURE_CARDDAV=false
 
-    if [ -n "$CURRENT_CARDDAV_EMAIL" ] && [ "$CURRENT_CARDDAV_EMAIL" != '""' ]; then
+    if [ -n "$CURRENT_CARDDAV_EMAIL" ]; then
         echo ""
         echo "Contact source: External CardDAV ($CURRENT_CARDDAV_EMAIL)"
         read -p "Change contact provider? [y/N]: " CHANGE_CONTACTS
@@ -283,8 +222,7 @@ if [ -t 0 ]; then
     fi
 
     if [ "$CONFIGURE_CARDDAV" = true ]; then
-        # Show menu if we're changing from an existing provider
-        if [ -n "$CURRENT_CARDDAV_EMAIL" ] && [ "$CURRENT_CARDDAV_EMAIL" != '""' ]; then
+        if [ -n "$CURRENT_CARDDAV_EMAIL" ]; then
             echo ""
             echo "  1) iCloud (remove external CardDAV)"
             echo "  2) Google Contacts (requires app password)"
@@ -300,19 +238,7 @@ if [ -t 0 ]; then
         CARDDAV_URL=""
 
         if [ "${CONTACT_CHOICE:-}" = "1" ]; then
-            # Remove external CardDAV — clear the config fields
-            python3 -c "
-import re
-text = open('$CONFIG').read()
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"\"')
-text = patch(text, 'url', '\"\"')
-text = patch(text, 'username', '\"\"')
-text = patch(text, 'password_encrypted', '\"\"')
-open('$CONFIG', 'w').write(text)
-"
-            rm -f "$CARDDAV_BACKUP"
+            sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.CardDAVEmail', '', '$.CardDAVURL', '', '$.CardDAVUsername', '', '$.CardDAVPasswordEncrypted', '');"
             echo "✓ Switched to iCloud contacts"
         elif [ -n "${CONTACT_CHOICE:-}" ]; then
             read -p "Email address: " CARDDAV_EMAIL
@@ -352,7 +278,6 @@ open('$CONFIG', 'w').write(text)
                 exit 1
             fi
 
-            # Encrypt password and patch config
             CARDDAV_ARGS="--email $CARDDAV_EMAIL --password $CARDDAV_PASSWORD --url $CARDDAV_URL"
             if [ -n "$CARDDAV_USERNAME" ]; then
                 CARDDAV_ARGS="$CARDDAV_ARGS --username $CARDDAV_USERNAME"
@@ -360,96 +285,16 @@ open('$CONFIG', 'w').write(text)
             CARDDAV_JSON=$("$BINARY" carddav-setup $CARDDAV_ARGS 2>/dev/null) || CARDDAV_JSON=""
 
             if [ -z "$CARDDAV_JSON" ]; then
-                echo "⚠  CardDAV setup failed. You can configure it manually in $CONFIG"
+                echo "⚠  CardDAV setup failed. You can reconfigure with 'set-carddav' in the bridge bot."
             else
                 CARDDAV_RESOLVED_URL=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])")
                 CARDDAV_ENC=$(echo "$CARDDAV_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['password_encrypted'])")
                 EFFECTIVE_USERNAME="${CARDDAV_USERNAME:-$CARDDAV_EMAIL}"
-                python3 -c "
-import re
-text = open('$CONFIG').read()
-def patch(text, key, val):
-    return re.sub(r'^(\s+' + re.escape(key) + r'\s*:)\s*.*$', r'\1 ' + val, text, count=1, flags=re.MULTILINE)
-text = patch(text, 'email', '\"$CARDDAV_EMAIL\"')
-text = patch(text, 'url', '\"$CARDDAV_RESOLVED_URL\"')
-text = patch(text, 'username', '\"$EFFECTIVE_USERNAME\"')
-text = patch(text, 'password_encrypted', '\"$CARDDAV_ENC\"')
-open('$CONFIG', 'w').write(text)
-"
+                sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.CardDAVEmail', '$CARDDAV_EMAIL', '$.CardDAVURL', '$CARDDAV_RESOLVED_URL', '$.CardDAVUsername', '$EFFECTIVE_USERNAME', '$.CardDAVPasswordEncrypted', '$CARDDAV_ENC');"
                 echo "✓ CardDAV configured: $CARDDAV_EMAIL → $CARDDAV_RESOLVED_URL"
-                cat > "$CARDDAV_BACKUP" << BKEOF
-SAVED_CARDDAV_EMAIL="$CARDDAV_EMAIL"
-SAVED_CARDDAV_URL="$CARDDAV_RESOLVED_URL"
-SAVED_CARDDAV_USERNAME="$EFFECTIVE_USERNAME"
-SAVED_CARDDAV_ENC="$CARDDAV_ENC"
-BKEOF
             fi
         fi
     fi
-fi
-
-# ── Check for existing login / prompt if needed ──────────────
-DB_URI=$(grep 'uri:' "$CONFIG" | head -1 | sed 's/.*uri: file://' | sed 's/?.*//')
-NEEDS_LOGIN=false
-
-if [ -z "$DB_URI" ] || [ ! -f "$DB_URI" ]; then
-    NEEDS_LOGIN=true
-elif command -v sqlite3 >/dev/null 2>&1; then
-    LOGIN_COUNT=$(sqlite3 "$DB_URI" "SELECT count(*) FROM user_login;" 2>/dev/null || echo "0")
-    if [ "$LOGIN_COUNT" = "0" ]; then
-        NEEDS_LOGIN=true
-    fi
-else
-    # sqlite3 not available — can't verify DB has logins, assume login needed
-    NEEDS_LOGIN=true
-fi
-
-# Require re-login if keychain trust-circle state is missing.
-# This catches upgrades from pre-keychain versions where the device-passcode
-# step was never run. If trustedpeers.plist exists with a user_identity, the
-# keychain was joined successfully and any transient PCS errors are harmless.
-SESSION_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mautrix-imessage"
-TRUSTEDPEERS_FILE="$SESSION_DIR/trustedpeers.plist"
-FORCE_CLEAR_STATE=false
-if [ "$NEEDS_LOGIN" = "false" ]; then
-    HAS_CLIQUE=false
-    if [ -f "$TRUSTEDPEERS_FILE" ]; then
-        if grep -q "<key>userIdentity</key>\|<key>user_identity</key>" "$TRUSTEDPEERS_FILE" 2>/dev/null; then
-            HAS_CLIQUE=true
-        fi
-    fi
-
-    if [ "$HAS_CLIQUE" != "true" ]; then
-        echo "⚠ Existing login found, but keychain trust-circle is not initialized."
-        echo "  Forcing fresh login so device-passcode step can run."
-        NEEDS_LOGIN=true
-        FORCE_CLEAR_STATE=true
-    fi
-fi
-
-if [ "$NEEDS_LOGIN" = "true" ]; then
-    echo ""
-    echo "┌─────────────────────────────────────────────────┐"
-    echo "│  No valid iMessage login found — starting login │"
-    echo "└─────────────────────────────────────────────────┘"
-    echo ""
-    # Stop the bridge if running (otherwise it holds the DB lock)
-    if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
-        systemctl --user stop mautrix-imessage
-    elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-        sudo systemctl stop mautrix-imessage
-    fi
-
-    if [ "${FORCE_CLEAR_STATE:-false}" = "true" ]; then
-        echo "Clearing stale local state before login..."
-        rm -f "$DB_URI" "$DB_URI-wal" "$DB_URI-shm"
-        rm -f "$SESSION_DIR/session.json" "$SESSION_DIR/identity.plist" "$SESSION_DIR/trustedpeers.plist"
-    fi
-
-    # Run login from DATA_DIR so that relative paths (state/anisette/)
-    # resolve to the same location as when systemd runs the bridge.
-    (cd "$DATA_DIR" && "$BINARY" login -c "$CONFIG")
-    echo ""
 fi
 
 # ── Optional shell shortcuts (asked before preferred handle so the
@@ -463,8 +308,8 @@ if systemctl --user list-unit-files mautrix-imessage.service 2>/dev/null | grep 
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
 elif systemctl list-unit-files mautrix-imessage.service 2>/dev/null | grep -q mautrix-imessage; then
-    _SHORTCUT_SYSCTL="sudo systemctl"
-    _SHORTCUT_JCTL="sudo journalctl"
+    _SHORTCUT_SYSCTL="systemctl"
+    _SHORTCUT_JCTL="journalctl"
 else
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
@@ -530,7 +375,6 @@ esac
 echo ""
 
 # ── Preferred handle (runs every time, can reconfigure) ────────
-HANDLE_BACKUP="$DATA_DIR/.preferred-handle"
 CURRENT_HANDLE=$(grep 'preferred_handle:' "$CONFIG" 2>/dev/null | head -1 | sed "s/.*preferred_handle: *//;s/['\"]//g" | tr -d ' ' || true)
 
 # Try to recover from backups if not set in config
@@ -540,9 +384,6 @@ if [ -z "$CURRENT_HANDLE" ]; then
     fi
     if [ -z "$CURRENT_HANDLE" ] && [ -f "$SESSION_DIR/session.json" ] && command -v python3 >/dev/null 2>&1; then
         CURRENT_HANDLE=$(python3 -c "import json; print(json.load(open('$SESSION_DIR/session.json')).get('preferred_handle',''))" 2>/dev/null || true)
-    fi
-    if [ -z "$CURRENT_HANDLE" ] && [ -f "$HANDLE_BACKUP" ]; then
-        CURRENT_HANDLE=$(cat "$HANDLE_BACKUP")
     fi
 fi
 
@@ -588,85 +429,27 @@ if [ -t 0 ] && [ "$NEEDS_LOGIN" = "false" ]; then
     fi
 fi
 
-# Write preferred handle to config (add key if missing, patch if present)
+# Write preferred handle to DB
 if [ -n "${CURRENT_HANDLE:-}" ]; then
-    if grep -q 'preferred_handle:' "$CONFIG" 2>/dev/null; then
-        sed -i "s|preferred_handle: .*|preferred_handle: '$CURRENT_HANDLE'|" "$CONFIG"
-    else
-        sed -i "/^network:/a\\    preferred_handle: '$CURRENT_HANDLE'" "$CONFIG"
+    if command -v sqlite3 >/dev/null 2>&1 && [ -n "${DB_URI:-}" ] && [ -f "${DB_URI:-}" ]; then
+        sqlite3 "$DB_URI" "UPDATE user_login SET metadata = json_set(metadata, '$.preferred_handle', '$CURRENT_HANDLE');"
     fi
     echo "✓ Preferred handle: $CURRENT_HANDLE"
-    echo "$CURRENT_HANDLE" > "$HANDLE_BACKUP"
 fi
 
-# ── Ensure video_transcoding key exists in config ──────────────
-if ! grep -q 'video_transcoding:' "$CONFIG" 2>/dev/null; then
-    sed -i '/cloudkit_backfill:/i\    video_transcoding: false' "$CONFIG"
-fi
-
-# ── Video transcoding (ffmpeg) ─────────────────────────────────
-CURRENT_VIDEO_TRANSCODING=$(grep 'video_transcoding:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*video_transcoding: *//' || true)
-if [ -t 0 ]; then
-    echo ""
-    echo "Video Transcoding:"
-    echo "  When enabled, non-MP4 videos (e.g. QuickTime .mov) are automatically"
-    echo "  converted to MP4 for broad Matrix client compatibility."
-    echo "  Requires ffmpeg."
-    echo ""
-    if [ "$CURRENT_VIDEO_TRANSCODING" = "true" ]; then
-        read -p "Enable video transcoding/remuxing? [Y/n]: " ENABLE_VT
-        case "$ENABLE_VT" in
-            [nN]*)
-                sed -i "s/video_transcoding: .*/video_transcoding: false/" "$CONFIG"
-                echo "✓ Video transcoding disabled"
-                ;;
-            *)
-                if ! command -v ffmpeg >/dev/null 2>&1; then
-                    echo "  ffmpeg not found — installing..."
-                    if command -v apt >/dev/null 2>&1; then
-                        sudo apt install -y ffmpeg
-                    elif command -v dnf >/dev/null 2>&1; then
-                        sudo dnf install -y ffmpeg
-                    elif command -v pacman >/dev/null 2>&1; then
-                        sudo pacman -S --noconfirm ffmpeg
-                    elif command -v zypper >/dev/null 2>&1; then
-                        sudo zypper install -y ffmpeg
-                    elif command -v apk >/dev/null 2>&1; then
-                        sudo apk add ffmpeg
-                    else
-                        echo "  ⚠ Could not detect package manager — please install ffmpeg manually"
-                    fi
-                fi
-                echo "✓ Video transcoding enabled"
-                ;;
-        esac
-    else
-        read -p "Enable video transcoding/remuxing? [y/N]: " ENABLE_VT
-        case "$ENABLE_VT" in
-            [yY]*)
-                sed -i "s/video_transcoding: .*/video_transcoding: true/" "$CONFIG"
-                if ! command -v ffmpeg >/dev/null 2>&1; then
-                    echo "  ffmpeg not found — installing..."
-                    if command -v apt >/dev/null 2>&1; then
-                        sudo apt install -y ffmpeg
-                    elif command -v dnf >/dev/null 2>&1; then
-                        sudo dnf install -y ffmpeg
-                    elif command -v pacman >/dev/null 2>&1; then
-                        sudo pacman -S --noconfirm ffmpeg
-                    elif command -v zypper >/dev/null 2>&1; then
-                        sudo zypper install -y ffmpeg
-                    elif command -v apk >/dev/null 2>&1; then
-                        sudo apk add ffmpeg
-                    else
-                        echo "  ⚠ Could not detect package manager — please install ffmpeg manually"
-                    fi
-                fi
-                echo "✓ Video transcoding enabled"
-                ;;
-            *)
-                echo "✓ Video transcoding disabled"
-                ;;
-        esac
+# ── Install ffmpeg if available (needed for video transcoding) ─
+echo "Checking for ffmpeg..."
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    if command -v apt >/dev/null 2>&1; then
+        apt install -y ffmpeg 2>/dev/null || true
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y ffmpeg 2>/dev/null || true
+    elif command -v pacman >/dev/null 2>&1; then
+        pacman -S --noconfirm ffmpeg 2>/dev/null || true
+    elif command -v zypper >/dev/null 2>&1; then
+        zypper install -y ffmpeg 2>/dev/null || true
+    elif command -v apk >/dev/null 2>&1; then
+        apk add ffmpeg 2>/dev/null || true
     fi
 fi
 
@@ -776,94 +559,19 @@ elif [ -t 0 ]; then
     fi
 fi
 
-# ── Ensure heic_conversion key exists in config ──────────────
-if ! grep -q 'heic_conversion:' "$CONFIG" 2>/dev/null; then
-    sed -i '/video_transcoding:/a\    heic_conversion: false' "$CONFIG"
-fi
-
-# ── HEIC conversion (libheif) ─────────────────────────────────
-CURRENT_HEIC_CONVERSION=$(grep 'heic_conversion:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_conversion: *//' || true)
-if [ -t 0 ]; then
-    echo ""
-    echo "HEIC Conversion:"
-    echo "  When enabled, HEIC/HEIF images are automatically converted to JPEG"
-    echo "  for broad Matrix client compatibility."
-    echo "  Requires libheif."
-    echo ""
-    if [ "$CURRENT_HEIC_CONVERSION" = "true" ]; then
-        read -p "Enable HEIC to JPEG conversion? [Y/n]: " ENABLE_HC
-        case "$ENABLE_HC" in
-            [nN]*)
-                sed -i "s/heic_conversion: .*/heic_conversion: false/" "$CONFIG"
-                echo "✓ HEIC conversion disabled"
-                ;;
-            *)
-                if command -v apt >/dev/null 2>&1; then
-                    dpkg -s libheif-dev >/dev/null 2>&1 || sudo apt install -y libheif-dev
-                elif command -v dnf >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo dnf install -y libheif-devel
-                elif command -v pacman >/dev/null 2>&1; then
-                    pacman -Qi libheif >/dev/null 2>&1 || sudo pacman -S --noconfirm libheif
-                elif command -v zypper >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo zypper install -y libheif-devel
-                elif command -v apk >/dev/null 2>&1; then
-                    apk info -e libheif-dev >/dev/null 2>&1 || sudo apk add libheif-dev
-                else
-                    echo "  ⚠ Could not detect package manager — please install libheif manually"
-                fi
-                echo "✓ HEIC conversion enabled"
-                ;;
-        esac
-    else
-        read -p "Enable HEIC to JPEG conversion? [y/N]: " ENABLE_HC
-        case "$ENABLE_HC" in
-            [yY]*)
-                sed -i "s/heic_conversion: .*/heic_conversion: true/" "$CONFIG"
-                if command -v apt >/dev/null 2>&1; then
-                    dpkg -s libheif-dev >/dev/null 2>&1 || sudo apt install -y libheif-dev
-                elif command -v dnf >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo dnf install -y libheif-devel
-                elif command -v pacman >/dev/null 2>&1; then
-                    pacman -Qi libheif >/dev/null 2>&1 || sudo pacman -S --noconfirm libheif
-                elif command -v zypper >/dev/null 2>&1; then
-                    rpm -q libheif-devel >/dev/null 2>&1 || sudo zypper install -y libheif-devel
-                elif command -v apk >/dev/null 2>&1; then
-                    apk info -e libheif-dev >/dev/null 2>&1 || sudo apk add libheif-dev
-                else
-                    echo "  ⚠ Could not detect package manager — please install libheif manually"
-                fi
-                echo "✓ HEIC conversion enabled"
-                ;;
-            *)
-                echo "✓ HEIC conversion disabled"
-                ;;
-        esac
-    fi
-fi
-
-# ── HEIC JPEG quality (only if HEIC conversion is enabled) ───
-HEIC_ENABLED=$(grep 'heic_conversion:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_conversion: *//' || true)
-if [ "$HEIC_ENABLED" = "true" ]; then
-    if ! grep -q 'heic_jpeg_quality:' "$CONFIG" 2>/dev/null; then
-        sed -i '/heic_conversion:/a\    heic_jpeg_quality: 95' "$CONFIG"
-    fi
-else
-    sed -i '/heic_jpeg_quality:/d' "$CONFIG"
-fi
-if [ "$HEIC_ENABLED" = "true" ] && [ -t 0 ]; then
-    CURRENT_QUALITY=$(grep 'heic_jpeg_quality:' "$CONFIG" 2>/dev/null | head -1 | sed 's/.*heic_jpeg_quality: *//' || echo "95")
-    [ -z "$CURRENT_QUALITY" ] && CURRENT_QUALITY=95
-    echo ""
-    read -p "JPEG quality for HEIC conversion (1–100) [$CURRENT_QUALITY]: " NEW_QUALITY
-    if [ -n "$NEW_QUALITY" ]; then
-        if [ "$NEW_QUALITY" -ge 1 ] 2>/dev/null && [ "$NEW_QUALITY" -le 100 ] 2>/dev/null; then
-            sed -i "s/heic_jpeg_quality: .*/heic_jpeg_quality: $NEW_QUALITY/" "$CONFIG"
-            echo "✓ JPEG quality set to $NEW_QUALITY"
-        else
-            echo "  ⚠ Invalid quality '$NEW_QUALITY' — keeping $CURRENT_QUALITY"
-        fi
-    else
-        echo "✓ JPEG quality: $CURRENT_QUALITY"
+# ── Install libheif if available (needed for HEIC conversion) ─
+echo "Checking for libheif..."
+if ! ldconfig -p 2>/dev/null | grep -q libheif || ! command -v heif-convert >/dev/null 2>&1; then
+    if command -v apt >/dev/null 2>&1; then
+        dpkg -s libheif-dev >/dev/null 2>&1 || apt install -y libheif-dev 2>/dev/null || true
+    elif command -v dnf >/dev/null 2>&1; then
+        rpm -q libheif-devel >/dev/null 2>&1 || dnf install -y libheif-devel 2>/dev/null || true
+    elif command -v pacman >/dev/null 2>&1; then
+        pacman -Qi libheif >/dev/null 2>&1 || pacman -S --noconfirm libheif 2>/dev/null || true
+    elif command -v zypper >/dev/null 2>&1; then
+        rpm -q libheif-devel >/dev/null 2>&1 || zypper install -y libheif-devel 2>/dev/null || true
+    elif command -v apk >/dev/null 2>&1; then
+        apk info -e libheif-dev >/dev/null 2>&1 || apk add libheif-dev 2>/dev/null || true
     fi
 fi
 
@@ -890,7 +598,7 @@ fi
 install_systemd_user() {
     # Enable lingering so user services survive SSH session closures
     if command -v loginctl >/dev/null 2>&1 && [ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null)" != "yes" ]; then
-        sudo loginctl enable-linger "$USER" 2>/dev/null || true
+        loginctl enable-linger "$USER" 2>/dev/null || true
     fi
     mkdir -p "$(dirname "$USER_SERVICE_FILE")"
     cat > "$USER_SERVICE_FILE" << EOF

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -176,7 +176,7 @@ if [ "$NEEDS_LOGIN" = "true" ]; then
     if systemctl --user is-active mautrix-imessage >/dev/null 2>&1; then
         systemctl --user stop mautrix-imessage
     elif systemctl is-active mautrix-imessage >/dev/null 2>&1; then
-        systemctl stop mautrix-imessage
+        sudo systemctl stop mautrix-imessage
     fi
 
     if [ "${FORCE_CLEAR_STATE:-false}" = "true" ]; then
@@ -308,8 +308,8 @@ if systemctl --user list-unit-files mautrix-imessage.service 2>/dev/null | grep 
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
 elif systemctl list-unit-files mautrix-imessage.service 2>/dev/null | grep -q mautrix-imessage; then
-    _SHORTCUT_SYSCTL="systemctl"
-    _SHORTCUT_JCTL="journalctl"
+    _SHORTCUT_SYSCTL="sudo systemctl"
+    _SHORTCUT_JCTL="sudo journalctl"
 else
     _SHORTCUT_SYSCTL="systemctl --user"
     _SHORTCUT_JCTL="journalctl --user"
@@ -441,15 +441,15 @@ fi
 echo "Checking for ffmpeg..."
 if ! command -v ffmpeg >/dev/null 2>&1; then
     if command -v apt >/dev/null 2>&1; then
-        apt install -y ffmpeg 2>/dev/null || true
+        sudo apt install -y ffmpeg 2>/dev/null || true
     elif command -v dnf >/dev/null 2>&1; then
-        dnf install -y ffmpeg 2>/dev/null || true
+        sudo dnf install -y ffmpeg 2>/dev/null || true
     elif command -v pacman >/dev/null 2>&1; then
-        pacman -S --noconfirm ffmpeg 2>/dev/null || true
+        sudo pacman -S --noconfirm ffmpeg 2>/dev/null || true
     elif command -v zypper >/dev/null 2>&1; then
-        zypper install -y ffmpeg 2>/dev/null || true
+        sudo zypper install -y ffmpeg 2>/dev/null || true
     elif command -v apk >/dev/null 2>&1; then
-        apk add ffmpeg 2>/dev/null || true
+        sudo apk add ffmpeg 2>/dev/null || true
     fi
 fi
 
@@ -563,15 +563,15 @@ fi
 echo "Checking for libheif..."
 if ! ldconfig -p 2>/dev/null | grep -q libheif || ! command -v heif-convert >/dev/null 2>&1; then
     if command -v apt >/dev/null 2>&1; then
-        dpkg -s libheif-dev >/dev/null 2>&1 || apt install -y libheif-dev 2>/dev/null || true
+        dpkg -s libheif-dev >/dev/null 2>&1 || sudo apt install -y libheif-dev 2>/dev/null || true
     elif command -v dnf >/dev/null 2>&1; then
-        rpm -q libheif-devel >/dev/null 2>&1 || dnf install -y libheif-devel 2>/dev/null || true
+        rpm -q libheif-devel >/dev/null 2>&1 || sudo dnf install -y libheif-devel 2>/dev/null || true
     elif command -v pacman >/dev/null 2>&1; then
-        pacman -Qi libheif >/dev/null 2>&1 || pacman -S --noconfirm libheif 2>/dev/null || true
+        pacman -Qi libheif >/dev/null 2>&1 || sudo pacman -S --noconfirm libheif 2>/dev/null || true
     elif command -v zypper >/dev/null 2>&1; then
-        rpm -q libheif-devel >/dev/null 2>&1 || zypper install -y libheif-devel 2>/dev/null || true
+        rpm -q libheif-devel >/dev/null 2>&1 || sudo zypper install -y libheif-devel 2>/dev/null || true
     elif command -v apk >/dev/null 2>&1; then
-        apk info -e libheif-dev >/dev/null 2>&1 || apk add libheif-dev 2>/dev/null || true
+        apk info -e libheif-dev >/dev/null 2>&1 || sudo apk add libheif-dev 2>/dev/null || true
     fi
 fi
 
@@ -598,7 +598,7 @@ fi
 install_systemd_user() {
     # Enable lingering so user services survive SSH session closures
     if command -v loginctl >/dev/null 2>&1 && [ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null)" != "yes" ]; then
-        loginctl enable-linger "$USER" 2>/dev/null || true
+        sudo loginctl enable-linger "$USER" 2>/dev/null || true
     fi
     mkdir -p "$(dirname "$USER_SERVICE_FILE")"
     cat > "$USER_SERVICE_FILE" << EOF


### PR DESCRIPTION
I've gone through with a similar approach to what I attempted before to make the bridge work in a generic homeserver environment so it can be deployed with MDAD.

The concept I followed was to:
- Move settings from config.yaml where applicable (user preference type of items)
- Handle all rustpush files on disk in such a way that they do not collide in multi-user environments
- Migrate onboarding flow from makefile & scripts to bridge bot standard login flow

So to summarize the changes:
- A dockerfile is added to generate docker images for use
- A few rustpush routines are modified to add a unique identifier to the files written to disk
- CardDAV, onboarding preferences, and more are moved to be stored to per-user database and are removed from the makefile path
- New bot commands are added to manage CardDAV and other settings
- Login flow expanded to set CardDAV etc during login per-user

The images build and they are working fine in a standalone environment. I need a hand testing a few other scenarios:

1. Beeper user to test `make install-beeper`
2. Someone with multiple iMessage users on a single homeserver to confirm functionality

The github actions can be stripped from the repo, if desired