### PR TITLE
fix(connector): prevent infinite disconnect hang during unknown-error reconnect

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1627,22 +1627,34 @@ func (c *IMClient) Disconnect() {
 		close(c.stopChan)
 		c.stopChan = nil
 	}
-	if c.client != nil {
-		c.client.Stop()
-		c.client.Destroy()
-		c.client = nil
-	}
-	// Tear down the APNs connection too (stop its ResourceManager + free the
-	// courier socket). A reconnect/relogin opens a NEW connection on the SAME
-	// device token; if the old one lingered, Apple drops the duplicate
-	// ("Failed to read message from APS ... early eof") and rustpush's
-	// no-backoff reconnect loop turns that into the self-sustaining
-	// receive-stall storm. Closing here guarantees the next connect starts
-	// clean. Close() only stops the underlying connection — it does NOT destroy
-	// the WrappedApsConnection Go object — so the receive-wedge watchdog
-	// polling it is never left holding a freed handle.
+	// Close the APNs ResourceManager before stopping the Client. The death
+	// signal aborts any ongoing generate() reconnect attempt inside the Tokio
+	// runtime, freeing worker threads that would otherwise prevent client.Stop()
+	// from being scheduled. Without this ordering, a prolonged reconnect storm
+	// can exhaust all Tokio workers and cause client.Stop() to block forever.
+	//
+	// Do NOT nil c.connection here — the watchdog goroutine may still be in its
+	// 5-second poll sleep and will call SecondsSinceLastInbound() before it sees
+	// the stopChan close. Close() is safe to call on a live WrappedApsConnection;
+	// it only signals the ResourceManager to stop, it does not free the Go object.
 	if c.connection != nil {
 		c.connection.Close()
+	}
+	if c.client != nil {
+		// Stop() is an async Rust/UniFFI call. Wrap it with a timeout so that a
+		// wedged Tokio runtime cannot block the reconnect path indefinitely.
+		stopDone := make(chan struct{})
+		go func() {
+			c.client.Stop()
+			close(stopDone)
+		}()
+		select {
+		case <-stopDone:
+		case <-time.After(10 * time.Second):
+			c.UserLogin.Log.Warn().Msg("client.Stop() timed out during disconnect; proceeding to destroy")
+		}
+		c.client.Destroy()
+		c.client = nil
 	}
 	if c.chatDB != nil {
 		c.chatDB.Close()


### PR DESCRIPTION
## Problem

When the receive-wedge watchdog fires `StateUnknownError` and the bridge attempts an auto-reconnect (introduced in a660050), `bsq.login.Disconnect()` hangs indefinitely, logging "Client disconnection taking long" every 2 seconds forever. Restarting the bridge fixes it. See #56 for logs.

## Root cause

`IMClient.Disconnect()` was calling `c.client.Stop()` (an async Rust/UniFFI call) **before** closing the APNs `ResourceManager`. After 600+ seconds of receive-wedge, the Rust reconnect storm leaves the Tokio runtime saturated with stale `generate()` tasks. With all worker threads occupied, the `stop()` future is never polled — and because `bridgev2` passes `timeout=0` to `DisconnectWithTimeout`, it waits forever.

The fix in a660050 added `c.connection.Close()` to `Disconnect()`, which would have solved this, but placed it *after* `c.client.Stop()` — too late to help.

## Fix

**1. Move `c.connection.Close()` before `c.client.Stop()`.**  
Sending the `ResourceManager` death signal first aborts any in-flight `generate()` reconnect attempt, freeing Tokio workers so `stop()` can be scheduled and complete.

**2. Wrap `c.client.Stop()` with a 10-second timeout.**  
Safety net: if the Tokio runtime is completely wedged, `Disconnect()` still completes in bounded time. `Destroy()` is called unconditionally afterward. The leaked goroutine (if any) blocks permanently waiting for a Tokio callback that will never arrive — which is safe since it never touches freed memory.

## Testing

Difficult to reproduce on demand (requires 10+ minutes of a wedged APNs receive path). The fix is a targeted reordering of two already-present calls plus a timeout guard.

Relates to #56.