### PR TITLE
Fix SMS/RCS group chats: stop splitting across rooms and mis-routing replies

### DIFF
--- a/pkg/connector/carrier_group_consolidation_test.go
+++ b/pkg/connector/carrier_group_consolidation_test.go
@@ -94,3 +94,64 @@ func TestPlanCarrierGroupConsolidation(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanCarrierRoomMoves(t *testing.T) {
+	const comma = "tel:+15551111111,tel:+15552222222"
+
+	tests := []struct {
+		name             string
+		canonicalHasRoom bool
+		members          []carrierMemberRoom
+		want             carrierRoomMovePlan
+	}{
+		{
+			// Canonical key already has a room: it must survive, and even a larger
+			// gid: room tombstones into it (ReIDPortal would otherwise tombstone the
+			// larger room — the bug this guards against).
+			name:             "existing canonical room survives over a larger member",
+			canonicalHasRoom: true,
+			members: []carrierMemberRoom{
+				{portalID: "gid:aaaa", hasRoom: true, msgCount: 9999},
+			},
+			want: carrierRoomMovePlan{survivor: comma, reIDs: []string{"gid:aaaa"}},
+		},
+		{
+			name:             "no canonical room: most-history member is renamed onto canonical first",
+			canonicalHasRoom: false,
+			members: []carrierMemberRoom{
+				{portalID: "gid:aaaa", hasRoom: true, msgCount: 10},
+				{portalID: "gid:bbbb", hasRoom: true, msgCount: 50},
+				{portalID: "gid:cccc", hasRoom: true, msgCount: 20},
+			},
+			want: carrierRoomMovePlan{survivor: "gid:bbbb", reIDs: []string{"gid:bbbb", "gid:aaaa", "gid:cccc"}},
+		},
+		{
+			name:             "members without rooms are skipped",
+			canonicalHasRoom: false,
+			members: []carrierMemberRoom{
+				{portalID: "gid:aaaa", hasRoom: false},
+				{portalID: "gid:bbbb", hasRoom: true, msgCount: 5},
+				{portalID: "gid:cccc", hasRoom: false},
+			},
+			want: carrierRoomMovePlan{survivor: "gid:bbbb", reIDs: []string{"gid:bbbb"}},
+		},
+		{
+			name:             "no member has a room: nothing to move, createPortals builds it",
+			canonicalHasRoom: false,
+			members: []carrierMemberRoom{
+				{portalID: "gid:aaaa", hasRoom: false},
+				{portalID: "gid:bbbb", hasRoom: false},
+			},
+			want: carrierRoomMovePlan{survivor: "", reIDs: nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planCarrierRoomMoves(comma, tt.canonicalHasRoom, tt.members)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("planCarrierRoomMoves() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/connector/carrier_group_consolidation_test.go
+++ b/pkg/connector/carrier_group_consolidation_test.go
@@ -83,11 +83,6 @@ func TestPlanCarrierGroupConsolidation(t *testing.T) {
 			},
 			want: nil,
 		},
-		{
-			name:    "no entries",
-			entries: nil,
-			want:    nil,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/connector/carrier_group_consolidation_test.go
+++ b/pkg/connector/carrier_group_consolidation_test.go
@@ -1,0 +1,101 @@
+package connector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPlanCarrierGroupConsolidation(t *testing.T) {
+	comma := "tel:+15551111111,tel:+15552222222"
+	commaB := "tel:+15553333333,tel:+15554444444"
+
+	tests := []struct {
+		name    string
+		entries []carrierConsolidationEntry
+		want    []carrierConsolidationGroup
+	}{
+		{
+			name: "multiple gid encodings collapse to one canonical group",
+			entries: []carrierConsolidationEntry{
+				{portalID: "gid:aaaa", canonical: comma},
+				{portalID: "gid:bbbb", canonical: comma},
+				{portalID: "gid:cccc", canonical: comma},
+			},
+			want: []carrierConsolidationGroup{
+				{canonical: comma, members: []string{"gid:aaaa", "gid:bbbb", "gid:cccc"}},
+			},
+		},
+		{
+			name: "single gid still re-keyed to participant form",
+			entries: []carrierConsolidationEntry{
+				{portalID: "gid:aaaa", canonical: comma},
+			},
+			want: []carrierConsolidationGroup{
+				{canonical: comma, members: []string{"gid:aaaa"}},
+			},
+		},
+		{
+			name: "already-canonical single portal is a no-op",
+			entries: []carrierConsolidationEntry{
+				{portalID: comma, canonical: comma},
+			},
+			want: nil,
+		},
+		{
+			name: "comma survivor plus gid duplicate still consolidates",
+			entries: []carrierConsolidationEntry{
+				{portalID: comma, canonical: comma},
+				{portalID: "gid:aaaa", canonical: comma},
+			},
+			want: []carrierConsolidationGroup{
+				{canonical: comma, members: []string{"gid:aaaa", comma}},
+			},
+		},
+		{
+			name: "distinct participant sets stay separate",
+			entries: []carrierConsolidationEntry{
+				{portalID: "gid:aaaa", canonical: comma},
+				{portalID: "gid:bbbb", canonical: comma},
+				{portalID: "gid:cccc", canonical: commaB},
+				{portalID: "gid:dddd", canonical: commaB},
+			},
+			want: []carrierConsolidationGroup{
+				{canonical: comma, members: []string{"gid:aaaa", "gid:bbbb"}},
+				{canonical: commaB, members: []string{"gid:cccc", "gid:dddd"}},
+			},
+		},
+		{
+			name: "duplicate portal IDs are de-duplicated within a group",
+			entries: []carrierConsolidationEntry{
+				{portalID: "gid:aaaa", canonical: comma},
+				{portalID: "gid:aaaa", canonical: comma},
+				{portalID: "gid:bbbb", canonical: comma},
+			},
+			want: []carrierConsolidationGroup{
+				{canonical: comma, members: []string{"gid:aaaa", "gid:bbbb"}},
+			},
+		},
+		{
+			name: "entries with empty canonical or portal are ignored",
+			entries: []carrierConsolidationEntry{
+				{portalID: "gid:aaaa", canonical: ""},
+				{portalID: "", canonical: comma},
+			},
+			want: nil,
+		},
+		{
+			name:    "no entries",
+			entries: nil,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planCarrierGroupConsolidation(tt.entries)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("planCarrierGroupConsolidation() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/connector/carrier_group_keying_test.go
+++ b/pkg/connector/carrier_group_keying_test.go
@@ -1,0 +1,140 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+)
+
+// self is the test login's own handle; the carrier portal key always includes
+// it (buildCanonicalParticipantList injects it). Chosen to sort first so the
+// expected canonical strings are easy to read.
+const (
+	selfHandle = "tel:+15550000000"
+	handleA    = "tel:+15551111111"
+	handleB    = "tel:+15552222222"
+	handleC    = "tel:+15553333333"
+)
+
+func testClient() *IMClient {
+	return &IMClient{
+		handle:     selfHandle,
+		allHandles: []string{selfHandle},
+	}
+}
+
+// TestCarrierGroupKeyConvergence is the load-bearing invariant of this whole
+// change: the backfill path (resolvePortalIDForCloudChat) and the live path
+// (makePortalKey's carrier branch) must derive the SAME portal key for a carrier
+// group, regardless of participant ordering, whether self is in the roster, or
+// which carrier service it is. If they diverge the group splits across rooms —
+// the exact bug this PR fixes.
+//
+// resolvePortalIDForCloudChat's carrier branch returns before any DB access, so
+// we exercise the real function. The live path's key is the same primitive
+// (strings.Join(buildCanonicalParticipantList(...), ",")); we assert the backfill
+// output equals it for every variant.
+func TestCarrierGroupKeyConvergence(t *testing.T) {
+	c := testClient()
+	canonical := selfHandle + "," + handleA + "," + handleB // sorted self,A,B
+
+	cases := []struct {
+		name         string
+		participants []string
+		service      string
+	}{
+		{"self omitted (relayed roster), SMS", []string{handleA, handleB}, "SMS"},
+		{"reordered participants", []string{handleB, handleA}, "SMS"},
+		{"self present in roster", []string{selfHandle, handleA, handleB}, "SMS"},
+		{"self present, reordered, duplicated", []string{handleB, selfHandle, handleA, handleA}, "SMS"},
+		{"RCS service", []string{handleA, handleB}, "RCS"},
+		{"MMS service", []string{handleA, handleB}, "MMS"},
+		{"lowercase service", []string{handleA, handleB}, "sms"},
+		{"service with whitespace", []string{handleA, handleB}, "  SMS "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Backfill path (real function; carrier branch is DB-free). style 43 = group.
+			got := c.resolvePortalIDForCloudChat(tc.participants, nil, "some-unstable-gid", 43, tc.service)
+			if got != canonical {
+				t.Fatalf("backfill key = %q, want %q", got, canonical)
+			}
+			// Live path derives its carrier key from the same primitive.
+			live := strings.Join(c.buildCanonicalParticipantList(tc.participants), ",")
+			if got != live {
+				t.Fatalf("backfill key %q != live primitive key %q — paths would split", got, live)
+			}
+		})
+	}
+}
+
+// TestCarrierGroupKeyIgnoresUnstableGid pins that the carrier key does NOT depend
+// on group_id: two records for the same participant set under different (unstable)
+// gid encodings must collapse to one key. This is the root cause the PR addresses.
+func TestCarrierGroupKeyIgnoresUnstableGid(t *testing.T) {
+	c := testClient()
+	parts := []string{handleA, handleB}
+	k1 := c.resolvePortalIDForCloudChat(parts, nil, "gid-encoding-aaaa", 43, "SMS")
+	k2 := c.resolvePortalIDForCloudChat(parts, nil, "GID-ENCODING-bbbb", 43, "SMS")
+	if k1 != k2 {
+		t.Fatalf("same carrier group under different gids produced %q and %q", k1, k2)
+	}
+	if !strings.Contains(k1, ",") || strings.HasPrefix(k1, "gid:") {
+		t.Fatalf("carrier group key should be a participant (comma) key, got %q", k1)
+	}
+}
+
+// TestNonCarrierGroupStillUsesGid guards that the carrier branch is correctly
+// scoped: an iMessage group with a group_id must keep its gid: key, untouched.
+func TestNonCarrierGroupStillUsesGid(t *testing.T) {
+	c := testClient()
+	got := c.resolvePortalIDForCloudChat([]string{handleA, handleB}, nil, "ABCD-1234", 43, "iMessage")
+	if got != "gid:abcd-1234" {
+		t.Fatalf("iMessage group key = %q, want gid:abcd-1234", got)
+	}
+}
+
+// TestCountNonSelfMembers covers the group/DM routing predicate, including the
+// relayed-carrier case where self is omitted and the reply arrives with fewer
+// participants than the group really has.
+func TestCountNonSelfMembers(t *testing.T) {
+	c := testClient()
+	s := func(v string) *string { return &v }
+
+	cases := []struct {
+		name         string
+		participants []string
+		sender       *string
+		want         int
+	}{
+		{"two others, no sender", []string{handleA, handleB}, nil, 2},
+		{"relayed group: sender duplicates a participant", []string{handleA, handleB}, s(handleA), 2},
+		{"relayed group: one participant + distinct sender", []string{handleA}, s(handleB), 2},
+		{"DM: one other + self in roster", []string{selfHandle, handleA}, s(handleA), 1},
+		{"DM: sender equals the only participant", []string{handleA}, s(handleA), 1},
+		{"order independent", []string{handleB, handleA, handleC}, nil, 3},
+		{"all self collapses to zero", []string{selfHandle, selfHandle}, s(selfHandle), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.countNonSelfMembers(tc.participants, tc.sender); got != tc.want {
+				t.Fatalf("countNonSelfMembers(%v, %v) = %d, want %d", tc.participants, tc.sender, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCarrierService(t *testing.T) {
+	carrier := []string{"SMS", "RCS", "MMS", "sms", "  rcs ", "MmS"}
+	for _, s := range carrier {
+		if !isCarrierService(s) {
+			t.Errorf("isCarrierService(%q) = false, want true", s)
+		}
+	}
+	notCarrier := []string{"iMessage", "imessage", "", "  ", "FaceTime", "unknown"}
+	for _, s := range notCarrier {
+		if isCarrierService(s) {
+			t.Errorf("isCarrierService(%q) = true, want false", s)
+		}
+	}
+}

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -3623,6 +3623,32 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 		finalPortalKey = newPortalKey
 	}
 
+	// Record the service type on the (possibly re-keyed) portal. Carrier groups
+	// re-key on membership change, and reIDPortalWithCacheUpdate only carries the
+	// SMS flag forward if the old portal already had one in memory — a group whose
+	// flag was never set this session would lose it, sending outbound replies over
+	// iMessage. Set it explicitly from msg.IsSms (this path doesn't go through
+	// handleMessage's updatePortalSMS) and persist on change so it survives a
+	// restart (loadSenderGuidsFromDB only hydrates IsSms=true entries).
+	if c.updatePortalSMS(string(finalPortalKey.ID), msg.IsSms) {
+		ctx := context.Background()
+		if p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, finalPortalKey); err == nil && p != nil {
+			meta, ok := p.Metadata.(*PortalMetadata)
+			if !ok {
+				meta = &PortalMetadata{}
+			}
+			if meta.IsSms != msg.IsSms {
+				meta.IsSms = msg.IsSms
+				p.Metadata = meta
+				if err := p.Save(ctx); err != nil {
+					log.Warn().Err(err).Str("portal_id", string(finalPortalKey.ID)).
+						Bool("is_sms", msg.IsSms).
+						Msg("Failed to persist IsSms after participant change")
+				}
+			}
+		}
+	}
+
 	// Cache sender_guid and group_name under the (possibly new) portal ID.
 	// For comma-based portals and gid: portals, cache the sender_guid so
 	// future messages can be resolved to this portal. This is skipped for

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -9984,6 +9984,9 @@ func (c *IMClient) indexGroupPortalLocked(portalID string) {
 	if c.groupPortalIndex == nil {
 		return
 	}
+	if !strings.Contains(portalID, ",") {
+		return // gid:/DM portals are not member-indexed (see ensureGroupPortalIndex)
+	}
 	for _, member := range strings.Split(portalID, ",") {
 		if c.groupPortalIndex[member] == nil {
 			c.groupPortalIndex[member] = make(map[string]bool)
@@ -10508,7 +10511,13 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 }
 
 func (c *IMClient) makePortalKey(participants []string, groupName *string, sender *string, senderGuid *string) networkid.PortalKey {
-	isGroup := c.getUniqueParticipantCount(participants) > 2 || (groupName != nil && *groupName != "")
+	// A conversation is a group when it has >=2 members besides us. Self is an
+	// implicit member on inbound, and relayed carrier-group messages omit self
+	// from the participant list (a 3-person group arrives with 2 participants),
+	// so count non-self members from participants AND sender rather than testing
+	// the raw participant count against ">2" — otherwise a group reply that omits
+	// self mis-routes into a 1:1 DM with one member.
+	isGroup := c.countNonSelfMembers(participants, sender) >= 2 || (groupName != nil && *groupName != "")
 
 	if isGroup {
 		// When a persistent group UUID (sender_guid / gid) is available,

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -10511,12 +10511,9 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 }
 
 func (c *IMClient) makePortalKey(participants []string, groupName *string, sender *string, senderGuid *string) networkid.PortalKey {
-	// A conversation is a group when it has >=2 members besides us. Self is an
-	// implicit member on inbound, and relayed carrier-group messages omit self
-	// from the participant list (a 3-person group arrives with 2 participants),
-	// so count non-self members from participants AND sender rather than testing
-	// the raw participant count against ">2" — otherwise a group reply that omits
-	// self mis-routes into a 1:1 DM with one member.
+	// Group = >=2 members besides us. Relayed carrier groups omit self, so a
+	// 3-person group arrives with 2 participants; count non-self members across
+	// participants AND sender so such a reply isn't mis-routed into a 1:1 DM.
 	isGroup := c.countNonSelfMembers(participants, sender) >= 2 || (groupName != nil && *groupName != "")
 
 	if isGroup {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -2914,7 +2914,7 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	// for messages that CloudKit already bridged. Check the Bridge DB for any
 	// message whose UUID is already known to prevent duplicates.
 	if msg.Uuid != "" {
-		portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+		portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 		if dbMsgs, err := c.Main.Bridge.DB.Message.GetAllPartsByID(
 			context.Background(), c.UserLogin.ID, makeMessageID(msg.Uuid),
 		); err == nil && len(dbMsgs) > 0 {
@@ -2962,7 +2962,7 @@ func (c *IMClient) handleMessage(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	}
 
 	sender := c.makeEventSender(msg.Sender)
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	sender = c.canonicalizeDMSender(portalKey, sender)
 
 	// Keep the stored gid: group roster in sync with the sender's current view
@@ -3335,7 +3335,7 @@ func (c *IMClient) handleTapback(log zerolog.Logger, msg rustpushgo.WrappedMessa
 	// self-reflections can still have participants=[self, self].
 	portalKey := c.resolvePortalByTargetMessage(log, targetGUID)
 	if portalKey.ID == "" {
-		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	}
 
 	// Persist the tapback UUID so cross-restart APNs re-deliveries are caught
@@ -3420,7 +3420,7 @@ func (c *IMClient) handleEdit(log zerolog.Logger, msg rustpushgo.WrappedMessage)
 	// determine the correct DM portal.
 	portalKey := c.resolvePortalByTargetMessage(log, targetGUID)
 	if portalKey.ID == "" {
-		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	}
 
 	newText := ptrStringOr(msg.EditNewText, "")
@@ -3470,7 +3470,7 @@ func (c *IMClient) handleUnsend(log zerolog.Logger, msg rustpushgo.WrappedMessag
 	// determine the correct DM portal.
 	portalKey := c.resolvePortalByTargetMessage(log, targetGUID)
 	if portalKey.ID == "" {
-		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+		portalKey = c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	}
 
 	// Scrub-before-emit, fail-closed: same pattern as handleMessageDelete.
@@ -3511,7 +3511,7 @@ func (c *IMClient) handleRename(log zerolog.Logger, msg rustpushgo.WrappedMessag
 		log.Debug().Str("uuid", msg.Uuid).Msg("Skipping stored rename message")
 		return
 	}
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	newName := ptrStringOr(msg.NewChatName, "")
 
 	// Update the cached iMessage group name to the NEW name so outbound
@@ -3571,7 +3571,7 @@ func (c *IMClient) handleParticipantChange(log zerolog.Logger, msg rustpushgo.Wr
 		return
 	}
 	// Resolve the existing portal from the OLD participant list.
-	oldPortalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	oldPortalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 
 	if len(msg.NewParticipants) == 0 {
 		// No new participant list — fall back to a resync with current info.
@@ -3775,7 +3775,7 @@ func (c *IMClient) fetchAndCacheGroupPhoto(ctx context.Context, log zerolog.Logg
 // valid MMCS data, letting us catch up on changes that occurred while offline.
 // If the MMCS URL has expired Rust returns nil bytes and we warn harmlessly.
 func (c *IMClient) handleIconChange(log zerolog.Logger, msg rustpushgo.WrappedMessage) {
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	portalID := string(portalKey.ID)
 	log = log.With().Str("portal_id", portalID).Bool("stored", msg.IsStoredMessage).Logger()
 
@@ -3879,7 +3879,7 @@ func (c *IMClient) handleNotifyAnyways(log zerolog.Logger, msg rustpushgo.Wrappe
 	}
 
 	ctx := context.Background()
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	portal, err := c.Main.Bridge.GetExistingPortalByKey(ctx, portalKey)
 	if err != nil || portal == nil || portal.MXID == "" {
 		log.Debug().Err(err).Msg("NotifyAnyways: no portal found, skipping notice")
@@ -3916,7 +3916,7 @@ func (c *IMClient) handleNotifyAnyways(log zerolog.Logger, msg rustpushgo.Wrappe
 
 func (c *IMClient) handleFaceTimeRingNotice(log zerolog.Logger, msg rustpushgo.WrappedMessage, rawText string) {
 	ctx := context.Background()
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	portal, err := c.Main.Bridge.GetExistingPortalByKey(ctx, portalKey)
 
 	senderHandle := ptrStringOr(msg.Sender, "")
@@ -4067,7 +4067,7 @@ func (c *IMClient) handleFaceTimeMissedNotice(log zerolog.Logger, msg rustpushgo
 		}
 	}
 
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	portal, err := c.Main.Bridge.GetExistingPortalByKey(ctx, portalKey)
 	sendNotice := func(roomID id.RoomID) error {
 		content := format.RenderMarkdown(noticeMarkdown, true, false)
@@ -4099,7 +4099,7 @@ func (c *IMClient) handleFaceTimeMissedNotice(log zerolog.Logger, msg rustpushgo
 func (c *IMClient) handleFaceTimeAnsweredElsewhereNotice(log zerolog.Logger, msg rustpushgo.WrappedMessage) {
 	ctx := context.Background()
 	notice := "📞 Incoming FaceTime call was answered on another device."
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	portal, err := c.Main.Bridge.GetExistingPortalByKey(ctx, portalKey)
 	sendNotice := func(roomID id.RoomID) error {
 		_, sendErr := c.Main.Bridge.Bot.SendMessage(ctx, roomID, event.EventMessage, &event.Content{
@@ -4225,7 +4225,7 @@ func (c *IMClient) makeDeletePortalKey(log zerolog.Logger, msg rustpushgo.Wrappe
 	}
 
 	log.Warn().Msg("Delete/recover message has no delete-specific fields, falling back to regular makePortalKey")
-	return c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	return c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 }
 
 func (c *IMClient) handleMessageDelete(log zerolog.Logger, msg rustpushgo.WrappedMessage) {
@@ -5573,7 +5573,7 @@ func (c *IMClient) handleReadReceipt(log zerolog.Logger, msg rustpushgo.WrappedM
 		}
 	}
 
-	portalKey := c.makeReceiptPortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makeReceiptPortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	ctx := context.Background()
 
 	// Try sender_guid lookup — first check gid: portal ID, then cache
@@ -5692,7 +5692,7 @@ func (c *IMClient) handleDeliveryReceipt(log zerolog.Logger, msg rustpushgo.Wrap
 	// format churn) silently drops every delivery receipt while read receipts
 	// keep working via their fallback chain — which manifests as "Beeper
 	// shows read but never delivered" with zero log signal.
-	portalKey := c.makeReceiptPortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makeReceiptPortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 	resolved := false
 
 	if msg.SenderGuid != nil && *msg.SenderGuid != "" {
@@ -5857,7 +5857,7 @@ func (c *IMClient) handleDeliveryReceipt(log zerolog.Logger, msg rustpushgo.Wrap
 }
 
 func (c *IMClient) handleTyping(log zerolog.Logger, msg rustpushgo.WrappedMessage) {
-	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid)
+	portalKey := c.makePortalKey(msg.Participants, msg.GroupName, msg.Sender, msg.SenderGuid, msg.IsSms)
 
 	// For group typing indicators, iMessage may only include [sender, target]
 	// without the full participant list. If the portal key resolves to a
@@ -10510,7 +10510,7 @@ func (c *IMClient) resolveExistingGroupByGid(gidPortalID string, senderGuid stri
 	return networkid.PortalID(gidPortalID)
 }
 
-func (c *IMClient) makePortalKey(participants []string, groupName *string, sender *string, senderGuid *string) networkid.PortalKey {
+func (c *IMClient) makePortalKey(participants []string, groupName *string, sender *string, senderGuid *string, isSms bool) networkid.PortalKey {
 	// Group = >=2 members besides us. Relayed carrier groups omit self, so a
 	// 3-person group arrives with 2 participants; count non-self members across
 	// participants AND sender so such a reply isn't mis-routed into a 1:1 DM.
@@ -10521,8 +10521,14 @@ func (c *IMClient) makePortalKey(participants []string, groupName *string, sende
 		// use "gid:<UUID>" as the stable portal ID. This avoids the
 		// fragility of participant-based IDs that break when membership
 		// changes or participants normalize differently.
+		//
+		// Carrier groups (SMS/RCS/MMS) are the exception: their group_id is
+		// unstable (CloudKit hands the same group back under several encodings),
+		// so we ignore senderGuid and key them purely by participant set — the
+		// same key resolvePortalIDForCloudChat uses — so the live and backfill
+		// paths converge on one room instead of splitting into a gid: room here.
 		var portalID networkid.PortalID
-		if senderGuid != nil && *senderGuid != "" {
+		if senderGuid != nil && *senderGuid != "" && !isSms {
 			gidID := "gid:" + strings.ToLower(*senderGuid)
 
 			// Fast path: check if we've previously resolved this gid to
@@ -10576,10 +10582,16 @@ func (c *IMClient) makePortalKey(participants []string, groupName *string, sende
 				}
 			}
 		} else {
-			// Fallback: build a participant-based ID for groups without a UUID.
+			// Fallback: build a participant-based ID for groups without a usable
+			// UUID. Carrier groups reach here even with senderGuid set; pass nil
+			// so their unstable guid is never associated with the portal.
 			deduped := c.buildCanonicalParticipantList(participants)
 			computedID := strings.Join(deduped, ",")
-			portalID = c.resolveExistingGroupPortalID(computedID, senderGuid)
+			sg := senderGuid
+			if isSms {
+				sg = nil
+			}
+			portalID = c.resolveExistingGroupPortalID(computedID, sg)
 		}
 		// Cache the actual iMessage group name (cv_name) so outbound
 		// messages can route to the correct conversation. Also push a
@@ -10771,9 +10783,9 @@ func (c *IMClient) makePortalKey(participants []string, groupName *string, sende
 // makeReceiptPortalKey handles receipt messages where participants may be empty.
 // When participants is empty (rustpush sets conversation: None for receipts),
 // use the sender field to identify the DM portal.
-func (c *IMClient) makeReceiptPortalKey(participants []string, groupName *string, sender *string, senderGuid *string) networkid.PortalKey {
+func (c *IMClient) makeReceiptPortalKey(participants []string, groupName *string, sender *string, senderGuid *string, isSms bool) networkid.PortalKey {
 	if len(participants) > 0 {
-		return c.makePortalKey(participants, groupName, sender, senderGuid)
+		return c.makePortalKey(participants, groupName, sender, senderGuid, isSms)
 	}
 	if sender != nil && *sender != "" {
 		// Resolve to existing portal for contacts with multiple numbers

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -2215,11 +2215,8 @@ type carrierGroupChatRow struct {
 }
 
 // listCarrierGroupChats returns the distinct group portals (gid: or comma) for
-// non-deleted carrier-service (SMS/RCS/MMS) chats, each with its normalized
-// participant roster. Used by consolidateCarrierGroupPortals to collapse the
-// same conversation recorded under multiple unstable gid: encodings (and across
-// services). DM portals (single remote handle) are excluded. Rows with an empty
-// roster are skipped — they can't be grouped.
+// non-deleted SMS/RCS/MMS chats, each with its normalized participant roster, for
+// consolidateCarrierGroupPortals. DM portals and empty-roster rows are excluded.
 func (s *cloudBackfillStore) listCarrierGroupChats(ctx context.Context) ([]carrierGroupChatRow, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT DISTINCT portal_id, participants_json FROM cloud_chat
@@ -2263,10 +2260,10 @@ func (s *cloudBackfillStore) listCarrierGroupChats(ctx context.Context) ([]carri
 }
 
 // reKeyPortalID re-points all cloud_chat and cloud_message rows from oldPortalID
-// to newPortalID and resets forward-backfill state so the re-keyed messages get
-// re-backfilled into the new portal's room. updated_ts is bumped so the portal
-// is not skipped by the "fully backfilled, no new content" startup filter.
-// Mirrors the existing normalizeGroup*PortalIDs migrations. No-op-safe.
+// to newPortalID and resets forward-backfill state so the re-keyed messages
+// re-backfill into the new portal's room. updated_ts is bumped so the portal
+// isn't skipped by the "fully backfilled, no new content" startup filter.
+// Mirrors the normalizeGroup*PortalIDs migrations. No-op-safe.
 func (s *cloudBackfillStore) reKeyPortalID(ctx context.Context, oldPortalID, newPortalID string) error {
 	if oldPortalID == "" || newPortalID == "" || oldPortalID == newPortalID {
 		return nil

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -2207,6 +2207,88 @@ func (s *cloudBackfillStore) resetForwardBackfillDone(ctx context.Context, porta
 	return err
 }
 
+// carrierGroupChatRow is one carrier-service (SMS/RCS/MMS) group cloud_chat row
+// used by the participant-set consolidation migration.
+type carrierGroupChatRow struct {
+	portalID     string
+	participants []string
+}
+
+// listCarrierGroupChats returns the distinct group portals (gid: or comma) for
+// non-deleted carrier-service (SMS/RCS/MMS) chats, each with its normalized
+// participant roster. Used by consolidateCarrierGroupPortals to collapse the
+// same conversation recorded under multiple unstable gid: encodings (and across
+// services). DM portals (single remote handle) are excluded. Rows with an empty
+// roster are skipped — they can't be grouped.
+func (s *cloudBackfillStore) listCarrierGroupChats(ctx context.Context) ([]carrierGroupChatRow, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT DISTINCT portal_id, participants_json FROM cloud_chat
+		 WHERE login_id=$1 AND UPPER(service) IN ('SMS','RCS','MMS') AND deleted=FALSE
+		   AND portal_id <> '' AND participants_json IS NOT NULL AND participants_json <> ''
+		   AND (portal_id LIKE 'gid:%' OR portal_id LIKE '%,%')`,
+		s.loginID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []carrierGroupChatRow
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var portalID, participantsJSON string
+		if err = rows.Scan(&portalID, &participantsJSON); err != nil {
+			return nil, err
+		}
+		if seen[portalID] {
+			continue
+		}
+		var raw []string
+		if err = json.Unmarshal([]byte(participantsJSON), &raw); err != nil {
+			continue
+		}
+		normalized := make([]string, 0, len(raw))
+		for _, p := range raw {
+			if n := normalizeIdentifierForPortalID(p); n != "" {
+				normalized = append(normalized, n)
+			}
+		}
+		if len(normalized) == 0 {
+			continue
+		}
+		seen[portalID] = true
+		out = append(out, carrierGroupChatRow{portalID: portalID, participants: normalized})
+	}
+	return out, rows.Err()
+}
+
+// reKeyPortalID re-points all cloud_chat and cloud_message rows from oldPortalID
+// to newPortalID and resets forward-backfill state so the re-keyed messages get
+// re-backfilled into the new portal's room. updated_ts is bumped so the portal
+// is not skipped by the "fully backfilled, no new content" startup filter.
+// Mirrors the existing normalizeGroup*PortalIDs migrations. No-op-safe.
+func (s *cloudBackfillStore) reKeyPortalID(ctx context.Context, oldPortalID, newPortalID string) error {
+	if oldPortalID == "" || newPortalID == "" || oldPortalID == newPortalID {
+		return nil
+	}
+	nowMS := time.Now().UnixMilli()
+	if _, err := s.db.Exec(ctx,
+		`UPDATE cloud_chat SET portal_id=$3, fwd_backfill_done=0, updated_ts=$4
+		 WHERE login_id=$1 AND portal_id=$2`,
+		s.loginID, oldPortalID, newPortalID, nowMS,
+	); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(ctx,
+		`UPDATE cloud_message SET portal_id=$3, updated_ts=$4
+		 WHERE login_id=$1 AND portal_id=$2`,
+		s.loginID, oldPortalID, newPortalID, nowMS,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
 // persistMessageUUID inserts a minimal cloud_message record for a realtime
 // APNs message so the UUID survives restarts. CloudKit-synced messages are
 // already stored via upsertMessageBatch; this covers the realtime path.

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -2220,7 +2220,7 @@ type carrierGroupChatRow struct {
 func (s *cloudBackfillStore) listCarrierGroupChats(ctx context.Context) ([]carrierGroupChatRow, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT DISTINCT portal_id, participants_json FROM cloud_chat
-		 WHERE login_id=$1 AND UPPER(service) IN ('SMS','RCS','MMS') AND deleted=FALSE
+		 WHERE login_id=$1 AND UPPER(TRIM(service)) IN ('SMS','RCS','MMS') AND deleted=FALSE
 		   AND portal_id <> '' AND participants_json IS NOT NULL AND participants_json <> ''
 		   AND (portal_id LIKE 'gid:%' OR portal_id LIKE '%,%')`,
 		s.loginID,

--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -736,7 +736,7 @@ func fnRestoreChatFromCloudKit(ce *commands.Event, login *bridgev2.UserLogin, cl
 		recoverableChats, err := client.client.ListRecoverableChats()
 		if err == nil {
 			for _, chat := range recoverableChats {
-				portalID := client.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style)
+				portalID := client.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style, chat.Service)
 				if portalID == "" || seenPortalIDs[portalID] {
 					continue
 				}
@@ -1231,7 +1231,7 @@ func fnRestoreDebug(ce *commands.Event) {
 				photo = " photo=" + g + "…"
 			}
 
-			portalID := client.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style)
+			portalID := client.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style, chat.Service)
 			cacheBackfillable := "?"
 			cacheContentful := "?"
 			if portalID != "" {

--- a/pkg/connector/contact_merge.go
+++ b/pkg/connector/contact_merge.go
@@ -139,38 +139,37 @@ func (c *IMClient) lookupContact(identifier string) *imessage.Contact {
 	return nil
 }
 
-// getUniqueParticipantCount counts the number of unique *people* in a
-// participant list by collapsing multiple self-handles into one and merging
-// handles that belong to the same contact.
-func (c *IMClient) getUniqueParticipantCount(participants []string) int {
+// countNonSelfMembers counts the unique non-self members of a conversation,
+// drawn from both the participant list and the sender. A contact's alternate
+// handles are collapsed so a multi-number contact isn't counted twice.
+//
+// This is the group/DM signal for inbound routing: self is always an implicit
+// member, so a conversation is a group when there are >=2 other members. Relayed
+// carrier-group messages (SMS/RCS/MMS) list only the OTHER members and omit
+// self, so a 3-person group arrives with 2 participants — counting raw
+// participants against ">2" misclassifies it as a DM and mis-delivers the reply
+// into a 1:1 with one of the members.
+func (c *IMClient) countNonSelfMembers(participants []string, sender *string) int {
 	seen := make(map[string]bool)
-	selfSeen := false
 	count := 0
-	for _, p := range participants {
-		normalized := normalizeIdentifierForPortalID(p)
-		if normalized == "" {
-			count++
-			continue
+	add := func(raw string) {
+		n := normalizeIdentifierForPortalID(raw)
+		if n == "" || c.isMyHandle(n) || seen[n] {
+			return
 		}
-		if c.isMyHandle(normalized) {
-			if !selfSeen {
-				selfSeen = true
-				count++
-			}
-			continue
-		}
-		if seen[normalized] {
-			continue
-		}
+		seen[n] = true
 		count++
-		seen[normalized] = true
-		contact := c.lookupContact(normalized)
-		if contact == nil {
-			continue
+		if contact := c.lookupContact(n); contact != nil {
+			for _, altID := range contactPortalIDs(contact) {
+				seen[altID] = true
+			}
 		}
-		for _, altID := range contactPortalIDs(contact) {
-			seen[altID] = true
-		}
+	}
+	for _, p := range participants {
+		add(p)
+	}
+	if sender != nil {
+		add(*sender)
 	}
 	return count
 }

--- a/pkg/connector/contact_merge.go
+++ b/pkg/connector/contact_merge.go
@@ -139,16 +139,11 @@ func (c *IMClient) lookupContact(identifier string) *imessage.Contact {
 	return nil
 }
 
-// countNonSelfMembers counts the unique non-self members of a conversation,
-// drawn from both the participant list and the sender. A contact's alternate
-// handles are collapsed so a multi-number contact isn't counted twice.
-//
-// This is the group/DM signal for inbound routing: self is always an implicit
-// member, so a conversation is a group when there are >=2 other members. Relayed
-// carrier-group messages (SMS/RCS/MMS) list only the OTHER members and omit
-// self, so a 3-person group arrives with 2 participants — counting raw
-// participants against ">2" misclassifies it as a DM and mis-delivers the reply
-// into a 1:1 with one of the members.
+// countNonSelfMembers counts the unique non-self members of a conversation
+// across the participant list and the sender, collapsing a contact's alternate
+// handles so a multi-number contact isn't double-counted. The group/DM signal
+// for inbound routing: self is implicit, so >=2 other members means a group.
+// Sender is included because relayed carrier groups omit self from participants.
 func (c *IMClient) countNonSelfMembers(participants []string, sender *string) int {
 	seen := make(map[string]bool)
 	count := 0

--- a/pkg/connector/group_identity.go
+++ b/pkg/connector/group_identity.go
@@ -6,6 +6,21 @@ func isGroupPortalID(portalID string) bool {
 	return strings.HasPrefix(portalID, "gid:") || strings.Contains(portalID, ",")
 }
 
+// isCarrierService reports whether a CloudKit chat service is a carrier
+// messaging service (SMS / RCS / MMS) rather than iMessage. Carrier group
+// conversations have no stable Apple group GUID — CloudKit hands the same group
+// back under several unstable group_id encodings — so they must be keyed by
+// participant set, not gid:. iMessage groups (and unknown/empty services) keep
+// their gid: key.
+func isCarrierService(service string) bool {
+	switch strings.ToUpper(strings.TrimSpace(service)) {
+	case "SMS", "RCS", "MMS":
+		return true
+	default:
+		return false
+	}
+}
+
 // normalizeUUID strips dashes and lowercases a UUID for comparison.
 // APNs sends dashless (520464eb701340d7bd9e7ae51684e430) while CloudKit
 // uses dashed (520464eb-7013-40d7-bd9e-7ae51684e430). This normalizes both.

--- a/pkg/connector/group_identity.go
+++ b/pkg/connector/group_identity.go
@@ -6,12 +6,10 @@ func isGroupPortalID(portalID string) bool {
 	return strings.HasPrefix(portalID, "gid:") || strings.Contains(portalID, ",")
 }
 
-// isCarrierService reports whether a CloudKit chat service is a carrier
-// messaging service (SMS / RCS / MMS) rather than iMessage. Carrier group
-// conversations have no stable Apple group GUID — CloudKit hands the same group
-// back under several unstable group_id encodings — so they must be keyed by
-// participant set, not gid:. iMessage groups (and unknown/empty services) keep
-// their gid: key.
+// isCarrierService reports whether a CloudKit chat service is SMS/RCS/MMS rather
+// than iMessage. Carrier groups have no stable Apple group GUID (CloudKit returns
+// them under several unstable group_id encodings), so they're keyed by participant
+// set, not gid:. iMessage and unknown/empty services keep their gid: key.
 func isCarrierService(service string) bool {
 	switch strings.ToUpper(strings.TrimSpace(service)) {
 	case "SMS", "RCS", "MMS":

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -2153,14 +2153,8 @@ func (c *IMClient) runCloudSyncController(log zerolog.Logger) {
 			Msg("Normalized inconsistent group message portal IDs using cloud_chat mappings")
 	}
 
-	// Consolidate carrier group chats that CloudKit recorded under multiple unstable
-	// gid: encodings (plain UUID / sha1-hex / hex-encoded UUID) into one room per
-	// participant set. Carrier groups have no stable group GUID, so the old gid: key
-	// shards one conversation across many rooms. This re-keys their cloud_chat/
-	// cloud_message rows to the canonical participant key and merges the existing
-	// rooms. Must run before createPortalsFromCloudSync so the canonical portal is
-	// the one created and (re-)backfilled. New splits are prevented at ingest by
-	// resolvePortalIDForCloudChat keying carrier groups by participants.
+	// Heal carrier groups that the old gid: key sharded across many rooms, before
+	// createPortalsFromCloudSync so the canonical portal is the one (re-)backfilled.
 	c.consolidateCarrierGroupPortals(ctx, log)
 
 	// Create portals and queue forward backfill for all of them.
@@ -3669,18 +3663,12 @@ func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayNam
 	// presence alone.
 	isGroup := style == 43
 
-	// Carrier group chats (SMS/RCS/MMS) have no stable Apple group GUID: CloudKit
-	// hands the same conversation back under several group_id encodings (plain
-	// UUID, sha1-hex, hex-encoded UUID) and even across services, so keying by
-	// gid: shards one group across many rooms. Key them by their participant set
-	// instead — the exact key the live message path uses (makePortalKey's
-	// no-senderGuid branch) — so backfill and live converge on one room.
-	// consolidateCarrierGroupPortals heals groups that already split under the
-	// old gid: scheme.
-	// Gate on >=2 non-self members so this matches makePortalKey's live group
-	// test exactly (same predicate). A degenerate carrier chat that reduces to
-	// just us — or a single remote handle — falls through to the DM/self-chat
-	// handling below instead of emitting a bogus self-only comma key.
+	// Carrier groups (SMS/RCS/MMS) have no stable Apple group GUID, so keying by
+	// gid: shards one group across many rooms. Key them by participant set — the
+	// same key makePortalKey's no-senderGuid branch uses — so backfill and live
+	// converge on one room (consolidateCarrierGroupPortals heals old gid: splits).
+	// The >=2 non-self gate matches makePortalKey's group test; a degenerate chat
+	// (just us, or one remote handle) falls through to DM/self-chat handling.
 	if isGroup && isCarrierService(service) && c.countNonSelfMembers(participants, nil) >= 2 {
 		return strings.Join(c.buildCanonicalParticipantList(participants), ",")
 	}
@@ -3730,25 +3718,23 @@ func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayNam
 	return string(portalKey.ID)
 }
 
-// carrierConsolidationEntry pairs a carrier group portal with the canonical participant
-// key its conversation should live under.
+// carrierConsolidationEntry pairs a carrier group portal with the canonical
+// participant key its conversation should live under.
 type carrierConsolidationEntry struct {
 	portalID  string
 	canonical string
 }
 
-// carrierConsolidationGroup is a set of carrier group portals that resolve to the same
-// canonical participant key and therefore need to be merged into one room.
+// carrierConsolidationGroup is the set of carrier group portals that resolve to
+// one canonical participant key and must be merged into a single room.
 type carrierConsolidationGroup struct {
 	canonical string
 	members   []string // distinct portal IDs sharing this canonical key, sorted
 }
 
-// planCarrierGroupConsolidation groups carrier group portals by canonical participant
-// key and returns the groups that need consolidation: those with more than one
-// distinct portal, or a single portal whose ID differs from the canonical key
-// (so it gets re-keyed to the participant form). Pure logic with no DB/room
-// access — the testable core of consolidateCarrierGroupPortals.
+// planCarrierGroupConsolidation groups portals by canonical key and returns those
+// needing consolidation: more than one portal, or a single portal whose ID isn't
+// already the canonical key. Pure logic — the testable core of the migration.
 func planCarrierGroupConsolidation(entries []carrierConsolidationEntry) []carrierConsolidationGroup {
 	byKey := make(map[string]map[string]bool)
 	for _, e := range entries {
@@ -3777,17 +3763,11 @@ func planCarrierGroupConsolidation(entries []carrierConsolidationEntry) []carrie
 	return out
 }
 
-// consolidateCarrierGroupPortals collapses carrier group conversations that were sharded
-// across multiple gid: rooms (CloudKit hands the same carrier group back under
-// several unstable group_id encodings) into one room per participant set. It
-// re-keys each duplicate's cloud_chat/cloud_message rows to the canonical
-// participant key, renames the room with the most history onto that key, and
-// tombstones the rest into it. The re-keyed messages re-backfill into the
-// survivor via the normal ChatResync forward/backward backfill (GUID-deduped),
-// so no history is lost.
-//
-// Runs inline at startup before createPortalsFromCloudSync. New splits are
-// prevented at ingest by resolvePortalIDForCloudChat.
+// consolidateCarrierGroupPortals collapses carrier groups sharded across multiple
+// gid: rooms into one room per participant set: re-keys each duplicate's cloud
+// rows to the canonical participant key, merges the rooms, and lets ChatResync
+// re-backfill (GUID-deduped, so no history is lost). Runs at startup before
+// createPortalsFromCloudSync; new splits are prevented at ingest.
 func (c *IMClient) consolidateCarrierGroupPortals(ctx context.Context, log zerolog.Logger) {
 	if c.cloudStore == nil {
 		return
@@ -3831,29 +3811,41 @@ func (c *IMClient) consolidateCarrierGroupPortals(ctx context.Context, log zerol
 	}
 }
 
-// consolidateOneCarrierGroup performs the data + room moves for a single carrier group.
-// Returns true if it took any action.
+// consolidateOneCarrierGroup performs the data + room moves for a single carrier
+// group. Returns true if it took any action.
 func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.Logger, g carrierConsolidationGroup) bool {
 	canonicalKey := networkid.PortalKey{ID: networkid.PortalID(g.canonical), Receiver: c.UserLogin.ID}
 
-	// Survivor = the existing member room with the most bridged Matrix messages
-	// (most history to keep, least to re-insert). May be empty if none have rooms.
+	// Pick the survivor — the live room the others are tombstoned into.
+	// reIDPortalWithCacheUpdate (ReIDPortal) can't merge two existing rooms; given
+	// (source, target) where target already has a room it tombstones the SOURCE.
+	// So if a room already holds the canonical key it MUST be the survivor —
+	// re-ID'ing a larger member onto it would tombstone that larger room, not
+	// keep it. Otherwise keep the member with the most bridged history and rename
+	// it onto the canonical key. Empty survivor = no member has a room yet;
+	// createPortalsFromCloudSync builds it from the re-keyed cloud_chat.
 	survivor := ""
-	survivorMsgs := -1
-	for _, m := range g.members {
-		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
-		p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, mk)
-		if err != nil || p == nil || p.MXID == "" {
-			continue
-		}
-		if n := c.countBridgedMessages(ctx, m); n > survivorMsgs {
-			survivorMsgs = n
-			survivor = m
+	if p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, canonicalKey); err == nil && p != nil && p.MXID != "" {
+		survivor = g.canonical
+	} else {
+		survivorMsgs := -1
+		for _, m := range g.members {
+			if m == g.canonical {
+				continue
+			}
+			mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
+			if p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, mk); err != nil || p == nil || p.MXID == "" {
+				continue
+			}
+			if n := c.countBridgedMessages(ctx, m); n > survivorMsgs {
+				survivorMsgs = n
+				survivor = m
+			}
 		}
 	}
 
-	// Re-key all members' cloud data to the canonical participant key so the
-	// consolidated room re-backfills the union of their messages.
+	// Re-key all members' cloud data to the canonical key so the survivor
+	// re-backfills the union of their messages.
 	for _, m := range g.members {
 		if err := c.cloudStore.reKeyPortalID(ctx, m, g.canonical); err != nil {
 			log.Warn().Err(err).Str("old_portal_id", m).Str("canonical", g.canonical).
@@ -3865,16 +3857,9 @@ func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.L
 			Msg("Failed to reset backfill state for canonical carrier portal")
 	}
 
-	// Move the rooms onto the canonical key: rename the survivor (carrying its
-	// history via the message FK ON UPDATE CASCADE), tombstone the rest into it.
-	// Members with no room are left for createPortalsFromCloudSync to create from
-	// the re-keyed cloud_chat.
-	//
-	// Edge: if a portal with the canonical key already exists (e.g. a live comma
-	// room) and a different member has more history, the re-ID below tombstones
-	// the larger room into the smaller canonical one. No data is lost — the
-	// re-keyed cloud_message rows re-backfill into the survivor — it just keeps
-	// the canonical-keyed room rather than the largest. Rare and self-correcting.
+	// Rename the survivor onto the canonical key (no-op if it already holds it),
+	// then tombstone every other member room into it. Members with no room are
+	// left for createPortalsFromCloudSync to build from the re-keyed cloud_chat.
 	if survivor != "" && survivor != g.canonical {
 		survivorKey := networkid.PortalKey{ID: networkid.PortalID(survivor), Receiver: c.UserLogin.ID}
 		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, survivorKey, canonicalKey); err != nil {
@@ -3898,7 +3883,6 @@ func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.L
 		Str("canonical", g.canonical).
 		Int("members", len(g.members)).
 		Str("survivor", survivor).
-		Int("survivor_msgs", survivorMsgs).
 		Msg("Consolidated carrier group portals")
 	return true
 }

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -2963,10 +2963,12 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 		}
 
 		// Update SMS flag from CloudKit chat service type. If a stale
-		// CloudKit record briefly clears the flag for a legitimately-SMS
-		// portal, the next live SMS message will re-set it immediately
-		// via handleMessage's unconditional updatePortalSMS call.
-		if strings.EqualFold(chat.Service, "SMS") {
+		// CloudKit record briefly clears the flag for a legitimately-carrier
+		// portal, the next live carrier message will re-set it immediately
+		// via handleMessage's unconditional updatePortalSMS call. Covers all
+		// carrier services (SMS/RCS/MMS), not just SMS, so RCS/MMS groups send
+		// over the carrier service rather than falling back to iMessage.
+		if isCarrierService(chat.Service) {
 			c.updatePortalSMS(portalID, true)
 		} else if strings.EqualFold(chat.Service, "iMessage") {
 			c.updatePortalSMS(portalID, false)

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -3811,38 +3811,81 @@ func (c *IMClient) consolidateCarrierGroupPortals(ctx context.Context, log zerol
 	}
 }
 
+// carrierMemberRoom is one member portal's Matrix-room state, gathered for the
+// room-move decision in planCarrierRoomMoves.
+type carrierMemberRoom struct {
+	portalID string
+	hasRoom  bool
+	msgCount int // bridged messages; only meaningful when hasRoom
+}
+
+// carrierRoomMovePlan is the decided set of room moves for one carrier group:
+// the survivor room kept as the live conversation, and the member portals whose
+// rooms are re-ID'd onto the canonical key (applied in order, survivor first).
+type carrierRoomMovePlan struct {
+	survivor string   // portal ID of the room kept; "" when no member has a room yet
+	reIDs    []string // portals to re-ID onto the canonical key, in apply order
+}
+
+// planCarrierRoomMoves decides which member room survives and which are merged
+// into it. reIDPortalWithCacheUpdate (ReIDPortal) tombstones the SOURCE when the
+// target room already exists, so a room already holding the canonical key must
+// be the survivor — re-ID'ing a larger member onto it would tombstone that
+// larger room. Otherwise the member with the most bridged history wins and is
+// renamed onto the canonical key (emitted first so it claims the key before the
+// rest tombstone into it). Members without a room are skipped — they're left for
+// createPortalsFromCloudSync to build from the re-keyed cloud_chat. Pure logic:
+// the tested core of consolidateOneCarrierGroup's room moves.
+func planCarrierRoomMoves(canonical string, canonicalHasRoom bool, members []carrierMemberRoom) carrierRoomMovePlan {
+	survivor := ""
+	if canonicalHasRoom {
+		survivor = canonical
+	} else {
+		best := -1
+		for _, m := range members {
+			if m.portalID == canonical || !m.hasRoom {
+				continue
+			}
+			if m.msgCount > best {
+				best = m.msgCount
+				survivor = m.portalID
+			}
+		}
+	}
+
+	plan := carrierRoomMovePlan{survivor: survivor}
+	if survivor != "" && survivor != canonical {
+		plan.reIDs = append(plan.reIDs, survivor)
+	}
+	for _, m := range members {
+		if !m.hasRoom || m.portalID == survivor || m.portalID == canonical {
+			continue
+		}
+		plan.reIDs = append(plan.reIDs, m.portalID)
+	}
+	return plan
+}
+
 // consolidateOneCarrierGroup performs the data + room moves for a single carrier
 // group. Returns true if it took any action.
 func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.Logger, g carrierConsolidationGroup) bool {
 	canonicalKey := networkid.PortalKey{ID: networkid.PortalID(g.canonical), Receiver: c.UserLogin.ID}
 
-	// Pick the survivor — the live room the others are tombstoned into.
-	// reIDPortalWithCacheUpdate (ReIDPortal) can't merge two existing rooms; given
-	// (source, target) where target already has a room it tombstones the SOURCE.
-	// So if a room already holds the canonical key it MUST be the survivor —
-	// re-ID'ing a larger member onto it would tombstone that larger room, not
-	// keep it. Otherwise keep the member with the most bridged history and rename
-	// it onto the canonical key. Empty survivor = no member has a room yet;
-	// createPortalsFromCloudSync builds it from the re-keyed cloud_chat.
-	survivor := ""
-	if p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, canonicalKey); err == nil && p != nil && p.MXID != "" {
-		survivor = g.canonical
-	} else {
-		survivorMsgs := -1
-		for _, m := range g.members {
-			if m == g.canonical {
-				continue
-			}
-			mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
-			if p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, mk); err != nil || p == nil || p.MXID == "" {
-				continue
-			}
-			if n := c.countBridgedMessages(ctx, m); n > survivorMsgs {
-				survivorMsgs = n
-				survivor = m
-			}
+	// Gather room state, then let planCarrierRoomMoves decide the survivor and the
+	// re-ID order (the irreversible part, kept pure and unit-tested).
+	members := make([]carrierMemberRoom, 0, len(g.members))
+	for _, m := range g.members {
+		if m == g.canonical {
+			continue
 		}
+		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
+		room := carrierMemberRoom{portalID: m, hasRoom: c.portalHasRoom(ctx, mk)}
+		if room.hasRoom {
+			room.msgCount = c.countBridgedMessages(ctx, m)
+		}
+		members = append(members, room)
 	}
+	plan := planCarrierRoomMoves(g.canonical, c.portalHasRoom(ctx, canonicalKey), members)
 
 	// Re-key all members' cloud data to the canonical key so the survivor
 	// re-backfills the union of their messages.
@@ -3857,34 +3900,32 @@ func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.L
 			Msg("Failed to reset backfill state for canonical carrier portal")
 	}
 
-	// Rename the survivor onto the canonical key (no-op if it already holds it),
-	// then tombstone every other member room into it. Members with no room are
-	// left for createPortalsFromCloudSync to build from the re-keyed cloud_chat.
-	if survivor != "" && survivor != g.canonical {
-		survivorKey := networkid.PortalKey{ID: networkid.PortalID(survivor), Receiver: c.UserLogin.ID}
-		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, survivorKey, canonicalKey); err != nil {
-			log.Warn().Err(err).Str("survivor", survivor).Str("canonical", g.canonical).
-				Msg("Failed to rename survivor carrier portal to canonical key")
-			return false
-		}
-	}
-	for _, m := range g.members {
-		if m == survivor || m == g.canonical {
-			continue
-		}
+	// Apply the room moves. The survivor rename (when present) is reIDs[0] and
+	// must claim the canonical key before the rest tombstone into it, so a failure
+	// there aborts rather than merging rooms into a non-canonical survivor.
+	for _, m := range plan.reIDs {
 		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
 		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, mk, canonicalKey); err != nil {
-			log.Warn().Err(err).Str("duplicate", m).Str("canonical", g.canonical).
-				Msg("Failed to merge duplicate carrier portal into canonical room")
+			log.Warn().Err(err).Str("portal", m).Str("canonical", g.canonical).
+				Msg("Failed to re-ID carrier portal onto canonical key")
+			if m == plan.survivor {
+				return false
+			}
 		}
 	}
 
 	log.Info().
 		Str("canonical", g.canonical).
 		Int("members", len(g.members)).
-		Str("survivor", survivor).
+		Str("survivor", plan.survivor).
 		Msg("Consolidated carrier group portals")
 	return true
+}
+
+// portalHasRoom reports whether a portal exists and has a Matrix room.
+func (c *IMClient) portalHasRoom(ctx context.Context, key networkid.PortalKey) bool {
+	p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, key)
+	return err == nil && p != nil && p.MXID != ""
 }
 
 // countBridgedMessages returns how many Matrix messages are bridged into the

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -3714,7 +3714,7 @@ func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayNam
 	if isGroup && groupID != "" {
 		senderGuidPtr = &groupID
 	}
-	portalKey := c.makePortalKey(normalizedParticipants, groupName, nil, senderGuidPtr)
+	portalKey := c.makePortalKey(normalizedParticipants, groupName, nil, senderGuidPtr, isCarrierService(service))
 	return string(portalKey.ID)
 }
 

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -375,7 +375,7 @@ func (c *IMClient) seedDeletedChatsFromRecycleBin(log zerolog.Logger) {
 		log.Info().Int("recoverable_chats", len(recoverableChats)).
 			Msg("DELETE-SEED: read recoverable chats, matching against local portal IDs")
 		for _, chat := range recoverableChats {
-			portalID := c.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style)
+			portalID := c.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style, chat.Service)
 			if portalID == "" {
 				log.Debug().
 					Str("record_name", chat.RecordName).
@@ -2153,6 +2153,16 @@ func (c *IMClient) runCloudSyncController(log zerolog.Logger) {
 			Msg("Normalized inconsistent group message portal IDs using cloud_chat mappings")
 	}
 
+	// Consolidate carrier group chats that CloudKit recorded under multiple unstable
+	// gid: encodings (plain UUID / sha1-hex / hex-encoded UUID) into one room per
+	// participant set. Carrier groups have no stable group GUID, so the old gid: key
+	// shards one conversation across many rooms. This re-keys their cloud_chat/
+	// cloud_message rows to the canonical participant key and merges the existing
+	// rooms. Must run before createPortalsFromCloudSync so the canonical portal is
+	// the one created and (re-)backfilled. New splits are prevented at ingest by
+	// resolvePortalIDForCloudChat keying carrier groups by participants.
+	c.consolidateCarrierGroupPortals(ctx, log)
+
 	// Create portals and queue forward backfill for all of them.
 	// Skip portals that are tombstoned or recently deleted this session.
 	portalStart := time.Now()
@@ -2952,7 +2962,7 @@ func (c *IMClient) ingestCloudChats(ctx context.Context, chats []rustpushgo.Wrap
 			continue
 		}
 
-		portalID := c.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style)
+		portalID := c.resolvePortalIDForCloudChat(chat.Participants, chat.DisplayName, chat.GroupId, chat.Style, chat.Service)
 		if portalID == "" {
 			counts.Skipped++
 			continue
@@ -3640,7 +3650,7 @@ func (c *IMClient) ingestCloudMessages(
 	return nil
 }
 
-func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayName *string, groupID string, style int64) string {
+func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayName *string, groupID string, style int64, service string) string {
 	normalizedParticipants := make([]string, 0, len(participants))
 	for _, participant := range participants {
 		normalized := normalizeIdentifierForPortalID(participant)
@@ -3658,6 +3668,22 @@ func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayNam
 	// field is set for ALL CloudKit chats, even DMs, so we can't use its
 	// presence alone.
 	isGroup := style == 43
+
+	// Carrier group chats (SMS/RCS/MMS) have no stable Apple group GUID: CloudKit
+	// hands the same conversation back under several group_id encodings (plain
+	// UUID, sha1-hex, hex-encoded UUID) and even across services, so keying by
+	// gid: shards one group across many rooms. Key them by their participant set
+	// instead — the exact key the live message path uses (makePortalKey's
+	// no-senderGuid branch) — so backfill and live converge on one room.
+	// consolidateCarrierGroupPortals heals groups that already split under the
+	// old gid: scheme.
+	// Gate on >=2 non-self members so this matches makePortalKey's live group
+	// test exactly (same predicate). A degenerate carrier chat that reduces to
+	// just us — or a single remote handle — falls through to the DM/self-chat
+	// handling below instead of emitting a bogus self-only comma key.
+	if isGroup && isCarrierService(service) && c.countNonSelfMembers(participants, nil) >= 2 {
+		return strings.Join(c.buildCanonicalParticipantList(participants), ",")
+	}
 
 	// For groups with a persistent group UUID, use gid:<UUID> as portal ID
 	if isGroup && groupID != "" {
@@ -3702,6 +3728,193 @@ func (c *IMClient) resolvePortalIDForCloudChat(participants []string, displayNam
 	}
 	portalKey := c.makePortalKey(normalizedParticipants, groupName, nil, senderGuidPtr)
 	return string(portalKey.ID)
+}
+
+// carrierConsolidationEntry pairs a carrier group portal with the canonical participant
+// key its conversation should live under.
+type carrierConsolidationEntry struct {
+	portalID  string
+	canonical string
+}
+
+// carrierConsolidationGroup is a set of carrier group portals that resolve to the same
+// canonical participant key and therefore need to be merged into one room.
+type carrierConsolidationGroup struct {
+	canonical string
+	members   []string // distinct portal IDs sharing this canonical key, sorted
+}
+
+// planCarrierGroupConsolidation groups carrier group portals by canonical participant
+// key and returns the groups that need consolidation: those with more than one
+// distinct portal, or a single portal whose ID differs from the canonical key
+// (so it gets re-keyed to the participant form). Pure logic with no DB/room
+// access — the testable core of consolidateCarrierGroupPortals.
+func planCarrierGroupConsolidation(entries []carrierConsolidationEntry) []carrierConsolidationGroup {
+	byKey := make(map[string]map[string]bool)
+	for _, e := range entries {
+		if e.canonical == "" || e.portalID == "" {
+			continue
+		}
+		if byKey[e.canonical] == nil {
+			byKey[e.canonical] = make(map[string]bool)
+		}
+		byKey[e.canonical][e.portalID] = true
+	}
+
+	var out []carrierConsolidationGroup
+	for canonical, set := range byKey {
+		members := make([]string, 0, len(set))
+		for id := range set {
+			members = append(members, id)
+		}
+		sort.Strings(members)
+		needs := len(members) > 1 || members[0] != canonical
+		if needs {
+			out = append(out, carrierConsolidationGroup{canonical: canonical, members: members})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].canonical < out[j].canonical })
+	return out
+}
+
+// consolidateCarrierGroupPortals collapses carrier group conversations that were sharded
+// across multiple gid: rooms (CloudKit hands the same carrier group back under
+// several unstable group_id encodings) into one room per participant set. It
+// re-keys each duplicate's cloud_chat/cloud_message rows to the canonical
+// participant key, renames the room with the most history onto that key, and
+// tombstones the rest into it. The re-keyed messages re-backfill into the
+// survivor via the normal ChatResync forward/backward backfill (GUID-deduped),
+// so no history is lost.
+//
+// Runs inline at startup before createPortalsFromCloudSync. New splits are
+// prevented at ingest by resolvePortalIDForCloudChat.
+func (c *IMClient) consolidateCarrierGroupPortals(ctx context.Context, log zerolog.Logger) {
+	if c.cloudStore == nil {
+		return
+	}
+	log = log.With().Str("component", "carrier_group_consolidation").Logger()
+
+	chats, err := c.cloudStore.listCarrierGroupChats(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to list carrier group chats for consolidation")
+		return
+	}
+	if len(chats) == 0 {
+		return
+	}
+
+	entries := make([]carrierConsolidationEntry, 0, len(chats))
+	for _, chat := range chats {
+		// Use the same >=2 non-self group rule as ingest/live so we only
+		// canonicalize genuine groups; a degenerate roster is left untouched.
+		if c.countNonSelfMembers(chat.participants, nil) < 2 {
+			continue
+		}
+		canonical := strings.Join(c.buildCanonicalParticipantList(chat.participants), ",")
+		entries = append(entries, carrierConsolidationEntry{portalID: chat.portalID, canonical: canonical})
+	}
+
+	groups := planCarrierGroupConsolidation(entries)
+	if len(groups) == 0 {
+		return
+	}
+
+	consolidated := 0
+	for _, g := range groups {
+		if c.consolidateOneCarrierGroup(ctx, log, g) {
+			consolidated++
+		}
+	}
+	if consolidated > 0 {
+		log.Info().Int("groups", consolidated).
+			Msg("Consolidated split carrier group portals by participant set")
+	}
+}
+
+// consolidateOneCarrierGroup performs the data + room moves for a single carrier group.
+// Returns true if it took any action.
+func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.Logger, g carrierConsolidationGroup) bool {
+	canonicalKey := networkid.PortalKey{ID: networkid.PortalID(g.canonical), Receiver: c.UserLogin.ID}
+
+	// Survivor = the existing member room with the most bridged Matrix messages
+	// (most history to keep, least to re-insert). May be empty if none have rooms.
+	survivor := ""
+	survivorMsgs := -1
+	for _, m := range g.members {
+		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
+		p, err := c.Main.Bridge.GetExistingPortalByKey(ctx, mk)
+		if err != nil || p == nil || p.MXID == "" {
+			continue
+		}
+		if n := c.countBridgedMessages(ctx, m); n > survivorMsgs {
+			survivorMsgs = n
+			survivor = m
+		}
+	}
+
+	// Re-key all members' cloud data to the canonical participant key so the
+	// consolidated room re-backfills the union of their messages.
+	for _, m := range g.members {
+		if err := c.cloudStore.reKeyPortalID(ctx, m, g.canonical); err != nil {
+			log.Warn().Err(err).Str("old_portal_id", m).Str("canonical", g.canonical).
+				Msg("Failed to re-key carrier group cloud data")
+		}
+	}
+	if err := c.cloudStore.resetForwardBackfillDone(ctx, g.canonical); err != nil {
+		log.Warn().Err(err).Str("canonical", g.canonical).
+			Msg("Failed to reset backfill state for canonical carrier portal")
+	}
+
+	// Move the rooms onto the canonical key: rename the survivor (carrying its
+	// history via the message FK ON UPDATE CASCADE), tombstone the rest into it.
+	// Members with no room are left for createPortalsFromCloudSync to create from
+	// the re-keyed cloud_chat.
+	//
+	// Edge: if a portal with the canonical key already exists (e.g. a live comma
+	// room) and a different member has more history, the re-ID below tombstones
+	// the larger room into the smaller canonical one. No data is lost — the
+	// re-keyed cloud_message rows re-backfill into the survivor — it just keeps
+	// the canonical-keyed room rather than the largest. Rare and self-correcting.
+	if survivor != "" && survivor != g.canonical {
+		survivorKey := networkid.PortalKey{ID: networkid.PortalID(survivor), Receiver: c.UserLogin.ID}
+		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, survivorKey, canonicalKey); err != nil {
+			log.Warn().Err(err).Str("survivor", survivor).Str("canonical", g.canonical).
+				Msg("Failed to rename survivor carrier portal to canonical key")
+			return false
+		}
+	}
+	for _, m := range g.members {
+		if m == survivor || m == g.canonical {
+			continue
+		}
+		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
+		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, mk, canonicalKey); err != nil {
+			log.Warn().Err(err).Str("duplicate", m).Str("canonical", g.canonical).
+				Msg("Failed to merge duplicate carrier portal into canonical room")
+		}
+	}
+
+	log.Info().
+		Str("canonical", g.canonical).
+		Int("members", len(g.members)).
+		Str("survivor", survivor).
+		Int("survivor_msgs", survivorMsgs).
+		Msg("Consolidated carrier group portals")
+	return true
+}
+
+// countBridgedMessages returns how many Matrix messages are bridged into the
+// given portal's room. Best-effort: returns 0 on error.
+func (c *IMClient) countBridgedMessages(ctx context.Context, portalID string) int {
+	var n int
+	err := c.Main.Bridge.DB.QueryRow(ctx,
+		`SELECT COUNT(*) FROM message WHERE bridge_id=$1 AND room_id=$2 AND room_receiver=$3`,
+		string(c.Main.Bridge.ID), portalID, string(c.UserLogin.ID),
+	).Scan(&n)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func (c *IMClient) createPortalsFromCloudSync(ctx context.Context, log zerolog.Logger, pendingDeletePortals map[string]bool) {

--- a/pkg/connector/sync_controller.go
+++ b/pkg/connector/sync_controller.go
@@ -3799,17 +3799,40 @@ func (c *IMClient) consolidateCarrierGroupPortals(ctx context.Context, log zerol
 		return
 	}
 
-	consolidated := 0
+	// Bound the Matrix room moves (re-ID / tombstone — each a homeserver round
+	// trip) performed per startup, so a large backlog of split groups can't stall
+	// startup or flood the homeserver with tombstones in one burst. The migration
+	// is idempotent and self-healing, so groups deferred here are consolidated on
+	// subsequent startups. At least one group always runs so progress is
+	// guaranteed even if a single group exceeds the budget on its own.
+	maxRooms := 0
 	for _, g := range groups {
-		if c.consolidateOneCarrierGroup(ctx, log, g) {
-			consolidated++
-		}
+		maxRooms += len(g.members)
 	}
-	if consolidated > 0 {
-		log.Info().Int("groups", consolidated).
-			Msg("Consolidated split carrier group portals by participant set")
+	log.Info().Int("groups", len(groups)).Int("max_member_rooms", maxRooms).
+		Msg("Planning carrier group consolidation")
+
+	consolidated, roomMoves := 0, 0
+	for _, g := range groups {
+		if consolidated > 0 && roomMoves >= carrierGroupRoomMoveBudgetPerStartup {
+			break
+		}
+		roomMoves += c.consolidateOneCarrierGroup(ctx, log, g)
+		consolidated++
+	}
+	deferred := len(groups) - consolidated
+	log.Info().Int("groups", consolidated).Int("room_moves", roomMoves).Int("deferred_groups", deferred).
+		Msg("Consolidated split carrier group portals by participant set")
+	if deferred > 0 {
+		log.Info().Int("deferred_groups", deferred).
+			Msg("Deferred remaining carrier group consolidations to next startup (room-move budget reached)")
 	}
 }
+
+// carrierGroupRoomMoveBudgetPerStartup caps how many room re-ID/tombstone
+// operations consolidateCarrierGroupPortals performs per startup. Bounds startup
+// latency and tombstone bursts; the rest converge on later startups (idempotent).
+const carrierGroupRoomMoveBudgetPerStartup = 50
 
 // carrierMemberRoom is one member portal's Matrix-room state, gathered for the
 // room-move decision in planCarrierRoomMoves.
@@ -3867,8 +3890,9 @@ func planCarrierRoomMoves(canonical string, canonicalHasRoom bool, members []car
 }
 
 // consolidateOneCarrierGroup performs the data + room moves for a single carrier
-// group. Returns true if it took any action.
-func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.Logger, g carrierConsolidationGroup) bool {
+// group. Returns the number of room re-ID/tombstone operations it attempted, so
+// the caller can budget room moves across groups per startup.
+func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.Logger, g carrierConsolidationGroup) int {
 	canonicalKey := networkid.PortalKey{ID: networkid.PortalID(g.canonical), Receiver: c.UserLogin.ID}
 
 	// Gather room state, then let planCarrierRoomMoves decide the survivor and the
@@ -3903,13 +3927,15 @@ func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.L
 	// Apply the room moves. The survivor rename (when present) is reIDs[0] and
 	// must claim the canonical key before the rest tombstone into it, so a failure
 	// there aborts rather than merging rooms into a non-canonical survivor.
+	moves := 0
 	for _, m := range plan.reIDs {
 		mk := networkid.PortalKey{ID: networkid.PortalID(m), Receiver: c.UserLogin.ID}
+		moves++
 		if _, _, err := c.reIDPortalWithCacheUpdate(ctx, mk, canonicalKey); err != nil {
 			log.Warn().Err(err).Str("portal", m).Str("canonical", g.canonical).
 				Msg("Failed to re-ID carrier portal onto canonical key")
 			if m == plan.survivor {
-				return false
+				return moves
 			}
 		}
 	}
@@ -3918,8 +3944,9 @@ func (c *IMClient) consolidateOneCarrierGroup(ctx context.Context, log zerolog.L
 		Str("canonical", g.canonical).
 		Int("members", len(g.members)).
 		Str("survivor", plan.survivor).
+		Int("room_moves", moves).
 		Msg("Consolidated carrier group portals")
-	return true
+	return moves
 }
 
 // portalHasRoom reports whether a portal exists and has a Matrix room.


### PR DESCRIPTION
## Problem
SMS/RCS/MMS group chats were split across many Matrix rooms, and some inbound replies landed in a 1:1 DM with the wrong contact.

## Root cause
- Carrier groups have no stable group GUID. CloudKit returns the same group under multiple group_id encodings, so the backfill path (gid:-keyed) and the live path (participant-keyed) diverged, and CloudKit alone produced many gid: rooms per group.
- Relayed carrier-group messages omit self, so a 3-person group's reply (2 participants) failed the ">2" group test and was routed as a DM, with the sender rewritten to the DM peer.

## Fix
- Key carrier groups by canonical participant set at ingest.
- Startup migration consolidates existing duplicates (re-key cloud rows + merge rooms; lossless re-backfill via ChatResync).
- Group detection counts non-self members (participants + sender), >=2.

## Validation
Reproduced from real DB state. After the change: the duplicate-roster query returns zero for carrier services; the worst case (10 rooms for one group) collapsed to a single room with full history; inbound replies from both an iMessage and an SMS member land in the group from the correct sender. iMessage groups and 1:1 DMs are unaffected.

This fixes https://github.com/lrhodin/corten-matrix/issues/58