### PR TITLE
fix(connector): bound connection.Close() with a timeout in Disconnect()

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1632,8 +1632,23 @@ func (c *IMClient) Disconnect() {
 	// can be scheduled. With the reverse ordering a prolonged reconnect storm can
 	// exhaust all workers and make Stop() block forever. Don't nil c.connection —
 	// the watchdog may still poll it; Close() signals stop without freeing the Go object.
+	//
+	// Close() is a synchronous Rust/UniFFI call, but during a prolonged
+	// receive-wedge ResourceManager's close() can itself contend with the
+	// same saturated Tokio runtime it's trying to tear down (see #56/#63).
+	// Bound it the same way as client.Stop() below so a wedge in either call
+	// can't hang Disconnect() indefinitely.
 	if c.connection != nil {
-		c.connection.Close()
+		closeDone := make(chan struct{})
+		go func() {
+			c.connection.Close()
+			close(closeDone)
+		}()
+		select {
+		case <-closeDone:
+		case <-time.After(10 * time.Second):
+			c.UserLogin.Log.Warn().Msg("connection.Close() timed out during disconnect; proceeding to client.Stop()")
+		}
 	}
 	if c.client != nil {
 		// Stop() is an async Rust/UniFFI call; bound it with a timeout so a wedged


### PR DESCRIPTION
## Problem

#63 fixed `client.Stop()` hanging forever during a receive-wedge reconnect by reordering `connection.Close()` before it and wrapping `Stop()` in a 10s timeout. The hang recurred — "Client disconnection taking long" spammed every 2s for 3.5 hours straight (see #56) — and critically, the `client.Stop() timed out during disconnect; proceeding to destroy` log line never appeared once during that window.

That line can only print once execution reaches the `client.Stop()` goroutine/`select` block, so its absence proves `Disconnect()` was stuck *before* that point.

## Root cause

`msgBuffer.stop()` and `close(stopChan)` are pure in-memory operations (mutex lock/unlock, channel close) with no I/O — they can't be the hang. That leaves `c.connection.Close()`, the only remaining FFI call before `client.Stop()`.

The #63 fix assumed `Close()` "only signals the ResourceManager to stop" and is always fast/non-blocking. But `Close()` calls into `rustpush::APSConnection::close()`, an external Rust crate — and under the same saturated-Tokio-runtime condition that wedges `Stop()`, there's no guarantee `Close()` itself can't block too (e.g. if it waits on a channel ack serviced by the same runtime).

## Fix

Apply the same goroutine + 10s timeout pattern already used for `client.Stop()` to `c.connection.Close()`. This bounds `Disconnect()`'s total worst-case latency to ~20s instead of unbounded, regardless of which FFI call is actually wedged.

It also makes future incidents diagnosable: the log will now show exactly which call timed out (`connection.Close()` vs `client.Stop()`), or neither — which would rule both out and point elsewhere.

## Caveat

This is a defensive fix based on strong circumstantial evidence, not a confirmed root cause — `rustpush::APSConnection::close()`'s implementation lives in an external crate fetched at build time (not in this repo), so it couldn't be inspected directly to confirm it blocks. If the new timeout fires in production, that confirms the theory and the underlying Rust behavior may still need a fix upstream.

Relates to #56, builds on #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)